### PR TITLE
fix: allow full lib reinitialization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@curvefi/llamalend-api",
-  "version": "1.0.6",
+  "version": "1.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curvefi/llamalend-api",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "JavaScript library for Curve Lending",
   "main": "lib/index.js",
   "author": "Macket",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { ethers, Networkish } from "ethers";
 import { LendMarketTemplate, getLendMarket } from "./lendMarkets/index.js";
 import { MintMarketTemplate, getMintMarket} from "./mintMarkets/index.js";
-import { llamalend as _llamalend} from "./llamalend.js";
+import { Llamalend } from "./llamalend.js";
 import {
     getBalances,
     getAllowance,
@@ -46,85 +46,88 @@ import {
     redeem,
 } from "./st-crvUSD.js";
 
+export const createLlamalend = () => {
+    const _llamalend = new Llamalend();
 
-async function init (
-    providerType: 'JsonRpc' | 'Web3' | 'Infura' | 'Alchemy',
-    providerSettings: { url?: string, privateKey?: string, batchMaxCount? : number } | { externalProvider: ethers.Eip1193Provider } | { network?: Networkish, apiKey?: string },
-    options: { gasPrice?: number, maxFeePerGas?: number, maxPriorityFeePerGas?: number, chainId?: number } = {}
-): Promise<void> {
-    await _llamalend.init(providerType, providerSettings, options);
-    // @ts-ignore
-    this.signerAddress = _llamalend.signerAddress;
-    // @ts-ignore
-    this.chainId = _llamalend.chainId;
-}
+    async function init (
+        providerType: 'JsonRpc' | 'Web3' | 'Infura' | 'Alchemy',
+        providerSettings: { url?: string, privateKey?: string, batchMaxCount? : number } | { externalProvider: ethers.Eip1193Provider } | { network?: Networkish, apiKey?: string },
+        options: { gasPrice?: number, maxFeePerGas?: number, maxPriorityFeePerGas?: number, chainId?: number } = {}
+    ): Promise<void> {
+        await _llamalend.init(providerType, providerSettings, options);
+        // @ts-ignore
+        this.signerAddress = _llamalend.signerAddress;
+        // @ts-ignore
+        this.chainId = _llamalend.chainId;
+    }
 
-function setCustomFeeData (customFeeData: { gasPrice?: number, maxFeePerGas?: number, maxPriorityFeePerGas?: number }): void {
-    _llamalend.setCustomFeeData(customFeeData);
-}
+    function setCustomFeeData (customFeeData: { gasPrice?: number, maxFeePerGas?: number, maxPriorityFeePerGas?: number }): void {
+        _llamalend.setCustomFeeData(customFeeData);
+    }
 
-const llamalend = {
-    init,
-    chainId: 0,
-    signerAddress: '',
-    LendMarketTemplate,
-    getLendMarket,
-    MintMarketTemplate,
-    getMintMarket,
-    totalSupply,
-    getLsdApy,
-    setCustomFeeData,
-    getBalances,
-    getAllowance,
-    hasAllowance,
-    ensureAllowance,
-    getUsdRate,
-    getGasPriceFromL1,
-    getGasPriceFromL2,
-    getGasInfoForL2,
-    fetchStats: _llamalend.fetchStats,
-    mintMarkets: {
-        getMarketList :_llamalend.getMintMarketList,
-    },
-    lendMarkets: {
-        fetchMarkets:  _llamalend.fetchLendMarkets,
-        getMarketList: _llamalend.getLendMarketList,
-    },
-    estimateGas: {
-        ensureAllowance: ensureAllowanceEstimateGas,
-    },
-    st_crvUSD: {
-        convertToAssets,
-        convertToShares,
-        userBalances,
-        totalSupplyAndCrvUSDLocked,
-        maxDeposit,
-        previewDeposit,
-        depositIsApproved,
-        depositAllowance,
-        depositApprove,
-        deposit,
-        maxMint,
-        previewMint,
-        mintIsApproved,
-        mintAllowance,
-        mintApprove,
-        mint,
-        maxWithdraw,
-        previewWithdraw,
-        withdraw,
-        maxRedeem,
-        previewRedeem,
-        redeem,
-        estimateGas: {
-            depositApprove: depositApproveEstimateGas,
-            deposit: depositEstimateGas,
-            mintApprove: mintApproveEstimateGas,
-            mint: mintEstimateGas,
-            withdraw: withdrawEstimateGas,
-            redeem: redeemEstimateGas,
+    return {
+        init,
+        chainId: 0,
+        signerAddress: '',
+        LendMarketTemplate,
+        getLendMarket,
+        MintMarketTemplate,
+        getMintMarket,
+        totalSupply,
+        getLsdApy,
+        setCustomFeeData,
+        getBalances,
+        getAllowance,
+        hasAllowance,
+        ensureAllowance,
+        getUsdRate,
+        getGasPriceFromL1,
+        getGasPriceFromL2,
+        getGasInfoForL2,
+        fetchStats: _llamalend.fetchStats,
+        mintMarkets: {
+            getMarketList :_llamalend.getMintMarketList,
         },
-    },
+        lendMarkets: {
+            fetchMarkets:  _llamalend.fetchLendMarkets,
+            getMarketList: _llamalend.getLendMarketList,
+        },
+        estimateGas: {
+            ensureAllowance: ensureAllowanceEstimateGas,
+        },
+        st_crvUSD: {
+            convertToAssets,
+            convertToShares,
+            userBalances,
+            totalSupplyAndCrvUSDLocked,
+            maxDeposit,
+            previewDeposit,
+            depositIsApproved,
+            depositAllowance,
+            depositApprove,
+            deposit,
+            maxMint,
+            previewMint,
+            mintIsApproved,
+            mintAllowance,
+            mintApprove,
+            mint,
+            maxWithdraw,
+            previewWithdraw,
+            withdraw,
+            maxRedeem,
+            previewRedeem,
+            redeem,
+            estimateGas: {
+                depositApprove: depositApproveEstimateGas,
+                deposit: depositEstimateGas,
+                mintApprove: mintApproveEstimateGas,
+                mint: mintEstimateGas,
+                withdraw: withdrawEstimateGas,
+                redeem: redeemEstimateGas,
+            },
+        },
+    }
 }
 
-export default llamalend;
+export default createLlamalend();

--- a/src/llamalend.ts
+++ b/src/llamalend.ts
@@ -169,7 +169,7 @@ export const NETWORK_CONSTANTS: { [index: number]: any } = {
 }
 
 
-class Llamalend implements ILlamalend {
+export class Llamalend implements ILlamalend {
     address: string;
     crvUsdAddress: string;
     provider: ethers.BrowserProvider | ethers.JsonRpcProvider;


### PR DESCRIPTION
- Wrap the default exported curve instance in a method. Add a named export this method. Do the same for the Curve class.
- Export a default instance for backwards compatibility