### PR TITLE
fix: repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ import { useState, useMemo } from 'react'
 import { providers } from 'ethers'
 import Onboard from 'bnc-onboard'
 import type { Wallet } from 'bnc-onboard/dist/src/interfaces'
-import llamalend from '@curvefi/lending-api'
+import llamalend from '@curvefi/llamalend-api'
     ...
 
 const WalletProvider: FunctionComponent = ({ children }) => {
@@ -79,7 +79,7 @@ import { useState, useMemo, useEffect } from 'react'
 import { providers } from 'ethers'
 import Onboard from 'bnc-onboard'
 import type { Wallet } from 'bnc-onboard/dist/src/interfaces'
-import llamalend from '@curvefi/lending-api'
+import llamalend from '@curvefi/llamalend-api'
 
     ...
 

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
   "private": false,
   "repository": {
     "type": "git",
-    "url": "https://github.com/curvefi/curve-lending-js.git"
+    "url": "https://github.com/curvefi/curve-llamalend.js.git"
   },
   "bugs": {
-    "url": "https://github.com/curvefi/curve-lending-js/issues"
+    "url": "https://github.com/curvefi/curve-llamalend.js/issues"
   },
   "scripts": {
     "build": "rm -rf lib && tsc --project tsconfig.build.json",


### PR DESCRIPTION
- commit links in releases are broken due to the old repository URL ([example](https://github.com/curvefi/curve-llamalend.js/releases/tag/v1.0.32))