### PR TITLE
fix: catch coingecko errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@curvefi/llamalend-api",
-  "version": "1.0.38",
+  "version": "1.0.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@curvefi/llamalend-api",
-      "version": "1.0.38",
+      "version": "1.0.39",
       "license": "MIT",
       "dependencies": {
         "@curvefi/ethcall": "6.0.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curvefi/llamalend-api",
-  "version": "1.0.38",
+  "version": "1.0.39",
   "description": "JavaScript library for Curve Lending",
   "main": "lib/index.js",
   "author": "Macket",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -361,11 +361,12 @@ export const _getUsdRate = async function (this: Llamalend, assetId: string): Pr
         const url = [nativeTokenName, 'ethereum', 'bitcoin', 'link', 'curve-dao-token', 'stasis-eurs'].includes(assetId.toLowerCase()) ?
             `https://api.coingecko.com/api/v3/simple/price?ids=${assetId}&vs_currencies=usd` :
             `https://api.coingecko.com/api/v3/simple/token_price/${chainName}?contract_addresses=${assetId}&vs_currencies=usd`
-        const response = await fetch(url);
-        const data = await response.json() as Record<string, { usd: number }>;
         try {
+            const response = await fetch(url);
+            const data = await response.json() as Record<string, { usd: number }>;
             _usdRatesCache[assetId] = {'rate': data[assetId]['usd'] ?? 0, 'time': Date.now()};
-        } catch { // TODO pay attention!
+        } catch {
+            // coingecko often fails due to 429 (rate limit) errors, due to missing CORS headers we get no details
             _usdRatesCache[assetId] = {'rate': 0, 'time': Date.now()};
         }
     }


### PR DESCRIPTION
- coingecko often fails due to 429 (rate limit) errors
- due to missing CORS headers we get no error details
- therefore, it's proper to catch all errors from coingecko
- related to https://github.com/curvefi/curve-frontend/pull/1642