### PR TITLE
fix: borrow more without collateral

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@curvefi/llamalend-api",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@curvefi/llamalend-api",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "MIT",
       "dependencies": {
         "@curvefi/ethcall": "6.0.16",
@@ -2589,9 +2589,9 @@
       }
     },
     "node_modules/mocha": {
-      "version": "11.7.4",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.4.tgz",
-      "integrity": "sha512-1jYAaY8x0kAZ0XszLWu14pzsf4KV740Gld4HXkhNTXwcHx4AUEDkPzgEHg9CM5dVcW+zv036tjpsEbLraPJj4w==",
+      "version": "11.7.5",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
+      "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curvefi/llamalend-api",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "JavaScript library for Curve Lending",
   "main": "lib/index.js",
   "author": "Macket",

--- a/src/external-api.ts
+++ b/src/external-api.ts
@@ -172,7 +172,7 @@ export const _getMarketsData = memoize(
 // --- ODOS ---
 
 export async function _getQuoteOdos(this: Llamalend, fromToken: string, toToken: string, _amount: bigint, blacklist: string, pathVizImage: boolean, slippage = 0.5): Promise<IQuoteOdos> {
-    if (_amount === BigInt(0)) return { outAmounts: ["0.0"], pathId: '', pathVizImage: '', priceImpact: 0, slippage };
+    if (_amount === BigInt(0)) return { outAmounts: ["0"], pathId: '', pathVizImage: '', priceImpact: 0, slippage };
 
     if (ethers.getAddress(fromToken) == "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE") fromToken = "0x0000000000000000000000000000000000000000";
     if (ethers.getAddress(toToken) == "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE") toToken = "0x0000000000000000000000000000000000000000";


### PR DESCRIPTION
- it should be possible to borrow more without adding any collateral. However, we currently get `SyntaxError: Cannot convert 0.0 to a BigInt (at LendMarketTemplate.js:379:43)`
- The error happened due to the BigInt conversion on [this line](https://github.com/curvefi/curve-llamalend.js/blob/56e2c6c5b76faa6929aab9dbb8b69db3c7d2417c/src/lendMarkets/LendMarketTemplate.ts#L2479)