### PR TITLE
feat: add minRecv for leverageZapV2 methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -986,15 +986,15 @@ interface ILeverageMetrics {
 }
 ```
 
-**2. Final methods now require `router` and `calldata` parameters**
+**2. Final methods now require `router`, `calldata` and `minRecv` parameters**
 - **Before**: `createLoan(userCollateral, userBorrowed, debt, range)`
-- **Now**: `createLoan(userCollateral, userBorrowed, debt, range, router, calldata)`
+- **Now**: `createLoan(userCollateral, userBorrowed, debt, range, minRecv, router, calldata)`
 - **Before**: `borrowMore(userCollateral, userBorrowed, debt, slippage)`
-- **Now**: `borrowMore(userCollateral, userBorrowed, debt, router, calldata)`
+- **Now**: `borrowMore(userCollateral, userBorrowed, debt, minRecv, router, calldata)`
 - **Before**: `repay(stateCollateral, userCollateral, userBorrowed, slippage)`
-- **Now**: `repay(stateCollateral, userCollateral, userBorrowed, router, calldata)`
+- **Now**: `repay(stateCollateral, userCollateral, userBorrowed, minRecv, router, calldata)`
 
-where `router` - address of router, `calldata` - calldata byte code
+where `router` - address of router, `calldata` - calldata byte code, `minRecv` - minimum amount of tokens to receive (see [Security Improvements](#security-improvements))
 
 #### Understanding Callback Functions and Quotes
 
@@ -1035,6 +1035,24 @@ interface IQuote {
 **For repay:**
 - Get quote for swapping `(stateCollateral + userCollateral)` collateral tokens → borrowed tokens
 - Example: For stateCollateral=2 and userCollateral=1, get quote for swapping 3 collateral tokens to borrowed tokens
+
+
+#### Security Improvements
+
+Execution methods (`createLoan`, `borrowMore`, `repay`) accept a `minRecv` parameter that guarantees the minimum amount of tokens received after the swap. This protects the user from slippage and frontrunning.
+
+Use `calcMinRecv(expected, slippage)` to compute the minimum acceptable amount:
+
+**Formula:** `minRecv = expected * (100 - slippage) / 100`
+
+- `expected` — expected amount of tokens from the swap
+- `slippage` — allowed slippage in percent (e.g. `0.5` for 0.5%)
+
+```ts
+// quote.outAmount — the expected amount from your router (computed on your side)
+const minRecv = lendMarket.leverageZapV2.calcMinRecv(quote.outAmount, 0.5); // 0.5% slippage
+await lendMarket.leverageZapV2.createLoan({ userCollateral, userBorrowed, debt, range, minRecv, router, calldata });
+```
 
 
 #### Leverage operations with routers
@@ -1120,8 +1138,12 @@ interface IQuote {
     // ]
 
     
+    // Calculate minRecv with slippage protection (see Security Improvements)
+    // expected — amount from your router quote
+    const minRecv = lendMarket.leverageZapV2.calcMinRecv(quote.outAmount, 0.5); // 0.5% slippage
+
     // Create loan, passing router address and calldata from router
-    await lendMarket.leverageZapV2.createLoan({ userCollateral, userBorrowed, debt, range, router, calldata });
+    await lendMarket.leverageZapV2.createLoan({ userCollateral, userBorrowed, debt, range, minRecv, router, calldata });
     // 0xeb1b7a92bcb02598f00dc8bbfe8fa3a554e7a2b1ca764e0ee45e2bf583edf731
 
     await lendMarket.wallet.balances();
@@ -1207,8 +1229,11 @@ interface IQuote {
     await lendMarket.leverageZapV2.borrowMoreApprove({ userCollateral, userBorrowed });
     // []
 
+    // Calculate minRecv with slippage protection (see Security Improvements)
+    const minRecvBM = lendMarket.leverageZapV2.calcMinRecv(quote.outAmount, 0.5); // 0.5% slippage
+
     // Execute borrowMore, passing router address and calldata from router
-    await lendMarket.leverageZapV2.borrowMore({ userCollateral, userBorrowed, debt, router, calldata });
+    await lendMarket.leverageZapV2.borrowMore({ userCollateral, userBorrowed, debt, minRecv: minRecvBM, router, calldata });
     // 0x6357dd6ea7250d7adb2344cd9295f8255fd8fbbe85f00120fbcd1ebf139e057c
 
     await lendMarket.wallet.balances();
@@ -1292,8 +1317,11 @@ interface IQuote {
     await lendMarket.leverageZapV2.repayApprove({ userCollateral, userBorrowed });
     // ['0xd8a8d3b3f67395e1a4f4d4f95b041edcaf1c9f7bab5eb8a8a767467678295498']
 
+    // Calculate minRecv with slippage protection (see Security Improvements)
+    const minRecvRepay = lendMarket.leverageZapV2.calcMinRecv(quote.outAmount, 0.5); // 0.5% slippage
+
     // Execute repay, passing router address and calldata from router
-    await lendMarket.leverageZapV2.repay({ stateCollateral, userCollateral, userBorrowed, router, calldata });
+    await lendMarket.leverageZapV2.repay({ stateCollateral, userCollateral, userBorrowed, minRecv: minRecvRepay, router, calldata });
     // 0xe48a97fef1c54180a2c7d104d210a95ac1a516fdd22109682179f1582da23a82
 
     await lendMarket.wallet.balances();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curvefi/llamalend-api",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "JavaScript library for Curve Lending",
   "main": "lib/index.js",
   "author": "Macket",

--- a/src/constants/aliases.ts
+++ b/src/constants/aliases.ts
@@ -49,7 +49,7 @@ export const ALIASES_ARBITRUM = lowerCaseValues({
     "gauge_factory": "0xabC000d88f23Bb45525E447528DBF656A9D55bf5",
     // "leverage_zap": "0x61C404B60ee9c5fB09F70F9A645DD38fE5b3A956", // 1inch
     "leverage_zap": "0xFE02553d3Ba4c3f39F36a4632F91404DF94b9AE2", // odos v3
-    "leverage_zap_v2": "0x5b07Db9a85992c877b9fBeA6DCC4F79292577640",
+    "leverage_zap_v2": "0x9577086c6E38d38359872F903Da201f1bdCc0323",
     "leverage_markets_start_id": "9",
 });
 

--- a/src/lendMarkets/LendMarketTemplate.ts
+++ b/src/lendMarkets/LendMarketTemplate.ts
@@ -410,6 +410,7 @@ export class LendMarketTemplate {
             createLoanIsApproved: leverageZapV2.leverageCreateLoanIsApproved.bind(leverageZapV2),
             createLoanApprove: leverageZapV2.leverageCreateLoanApprove.bind(leverageZapV2),
             createLoanExpectedMetrics: leverageZapV2.leverageCreateLoanExpectedMetrics.bind(leverageZapV2),
+            calcMinRecv: leverageZapV2.calcMinRecv.bind(leverageZapV2),
             createLoan: leverageZapV2.leverageCreateLoan.bind(leverageZapV2),
 
             borrowMoreMaxRecv: leverageZapV2.leverageBorrowMoreMaxRecv.bind(leverageZapV2),

--- a/src/lendMarkets/interfaces/leverageZapV2.ts
+++ b/src/lendMarkets/interfaces/leverageZapV2.ts
@@ -125,11 +125,13 @@ export interface ILeverageZapV2 {
         userCollateral: TAmount,
         userBorrowed: TAmount
     }) => Promise<string[]>,
+    calcMinRecv: (expected: TAmount, slippage: number) => string,
     createLoan: ({
         userCollateral,
         userBorrowed,
         debt,
         range,
+        minRecv,
         router,
         calldata,
     }: {
@@ -137,6 +139,7 @@ export interface ILeverageZapV2 {
         userBorrowed: TAmount,
         debt: TAmount,
         range: number,
+        minRecv: TAmount,
         router: string,
         calldata: string
     }) => Promise<string>,
@@ -183,10 +186,11 @@ export interface ILeverageZapV2 {
         userCollateral: TAmount,
         userBorrowed: TAmount
     }) => Promise<string[]>,
-    borrowMore: ({ userCollateral, userBorrowed, debt, router, calldata }: {
+    borrowMore: ({ userCollateral, userBorrowed, debt, minRecv, router, calldata }: {
         userCollateral: TAmount,
         userBorrowed: TAmount,
         debt: TAmount,
+        minRecv: TAmount,
         router: string,
         calldata: string
     }) => Promise<string>,
@@ -240,10 +244,11 @@ export interface ILeverageZapV2 {
         userCollateral: TAmount,
         userBorrowed: TAmount
     }) => Promise<string[]>,
-    repay: ({ stateCollateral, userCollateral, userBorrowed, router, calldata }: {
+    repay: ({ stateCollateral, userCollateral, userBorrowed, minRecv, router, calldata }: {
         stateCollateral: TAmount,
         userCollateral: TAmount,
         userBorrowed: TAmount,
+        minRecv: TAmount,
         router: string,
         calldata: string
     }) => Promise<string>,
@@ -260,11 +265,12 @@ export interface ILeverageZapV2 {
             userCollateral: TAmount,
             userBorrowed: TAmount
         }) => Promise<TGas>,
-        createLoan: ({ userCollateral, userBorrowed, debt, range, router, calldata }: {
+        createLoan: ({ userCollateral, userBorrowed, debt, range, minRecv, router, calldata }: {
             userCollateral: TAmount,
             userBorrowed: TAmount,
             debt: TAmount,
             range: number,
+            minRecv: TAmount,
             router: string,
             calldata: string
         }) => Promise<number>,
@@ -273,10 +279,11 @@ export interface ILeverageZapV2 {
             userCollateral: TAmount,
             userBorrowed: TAmount
         }) => Promise<TGas>,
-        borrowMore: ({ userCollateral, userBorrowed, debt, router, calldata }: {
+        borrowMore: ({ userCollateral, userBorrowed, debt, minRecv, router, calldata }: {
             userCollateral: TAmount,
             userBorrowed: TAmount,
             debt: TAmount,
+            minRecv: TAmount,
             router: string,
             calldata: string
         }) => Promise<number>,
@@ -285,10 +292,11 @@ export interface ILeverageZapV2 {
             userCollateral: TAmount,
             userBorrowed: TAmount
         }) => Promise<TGas>,
-        repay: ({ stateCollateral, userCollateral, userBorrowed, router, calldata }: {
+        repay: ({ stateCollateral, userCollateral, userBorrowed, minRecv, router, calldata }: {
             stateCollateral: TAmount,
             userCollateral: TAmount,
             userBorrowed: TAmount,
+            minRecv: TAmount,
             router: string,
             calldata: string
         }) => Promise<number>,

--- a/src/lendMarkets/modules/leverageZapV2.ts
+++ b/src/lendMarkets/modules/leverageZapV2.ts
@@ -70,6 +70,11 @@ export class LeverageZapV2Module {
         return BN(1).div(BN(1).minus(k_effective_BN)).toString()
     }
 
+    public calcMinRecv(expected: TAmount, slippage: number): string {
+        if (slippage < 0 || slippage > 100) throw Error("Slippage must be between 0 and 100");
+        return BN(expected).times(BN(100).minus(slippage)).div(100).toString();
+    }
+
     public async leverageCreateLoanMaxRecv({ userCollateral, userBorrowed, range, getExpected }: {
         userCollateral: TAmount,
         userBorrowed: TAmount,
@@ -484,6 +489,7 @@ export class LeverageZapV2Module {
         userBorrowed: TAmount,
         debt: TAmount,
         range: number,
+        minRecv: TAmount,
         router: string,
         calldata: string,
         estimateGas: boolean
@@ -494,6 +500,7 @@ export class LeverageZapV2Module {
         const _userCollateral = parseUnits(userCollateral, this.market.collateral_token.decimals);
         const _userBorrowed = parseUnits(userBorrowed, this.market.borrowed_token.decimals);
         const _debt = parseUnits(debt, this.market.borrowed_token.decimals);
+        const _minRecv = parseUnits(minRecv, this.market.collateral_token.decimals);
 
 
         const zapCalldata = buildCalldataForLeverageZapV2(router, calldata)
@@ -503,7 +510,7 @@ export class LeverageZapV2Module {
             _debt,
             range,
             this.llamalend.constants.ALIASES.leverage_zap_v2,
-            [0, parseUnits(this._getMarketId(), 0), _userBorrowed],
+            [0, parseUnits(this._getMarketId(), 0), _userBorrowed, _minRecv],
             zapCalldata,
             { ...this.llamalend.constantOptions }
         );
@@ -516,36 +523,38 @@ export class LeverageZapV2Module {
             _debt,
             range,
             this.llamalend.constants.ALIASES.leverage_zap_v2,
-            [0, parseUnits(this._getMarketId(), 0), _userBorrowed],
+            [0, parseUnits(this._getMarketId(), 0), _userBorrowed, _minRecv],
             zapCalldata,
             { ...this.llamalend.options, gasLimit }
         )).hash
     }
 
-    public async leverageCreateLoanEstimateGas({ userCollateral, userBorrowed, debt, range, router, calldata }: {
+    public async leverageCreateLoanEstimateGas({ userCollateral, userBorrowed, debt, range, minRecv, router, calldata }: {
         userCollateral: TAmount,
         userBorrowed: TAmount,
         debt: TAmount,
         range: number,
+        minRecv: TAmount,
         router: string,
         calldata: string
     }): Promise<number> {
         this._checkLeverageZap();
         if (!(await this.leverageCreateLoanIsApproved({ userCollateral, userBorrowed }))) throw Error("Approval is needed for gas estimation");
-        return await this._leverageCreateLoan(userCollateral, userBorrowed, debt, range, router, calldata,  true) as number;
+        return await this._leverageCreateLoan(userCollateral, userBorrowed, debt, range, minRecv, router, calldata,  true) as number;
     }
 
-    public async leverageCreateLoan({ userCollateral, userBorrowed, debt, range, router, calldata }: {
+    public async leverageCreateLoan({ userCollateral, userBorrowed, debt, range, minRecv, router, calldata }: {
         userCollateral: TAmount,
         userBorrowed: TAmount,
         debt: TAmount,
         range: number,
+        minRecv: TAmount,
         router: string,
         calldata: string
     }): Promise<string> {
         this._checkLeverageZap();
         await this.leverageCreateLoanApprove({ userCollateral, userBorrowed });
-        return await this._leverageCreateLoan(userCollateral, userBorrowed, debt, range, router, calldata, false) as string;
+        return await this._leverageCreateLoan(userCollateral, userBorrowed, debt, range, minRecv, router, calldata, false) as string;
     }
 
     // ---------------- LEVERAGE BORROW MORE ----------------
@@ -667,6 +676,7 @@ export class LeverageZapV2Module {
         userCollateral: TAmount,
         userBorrowed: TAmount,
         debt: TAmount,
+        minRecv: TAmount,
         router: string,
         calldata: string,
         estimateGas: boolean
@@ -675,6 +685,7 @@ export class LeverageZapV2Module {
         const _userCollateral = parseUnits(userCollateral, this.market.collateral_token.decimals);
         const _userBorrowed = parseUnits(userBorrowed, this.market.borrowed_token.decimals);
         const _debt = parseUnits(debt, this.market.borrowed_token.decimals);
+        const _minRecv = parseUnits(minRecv, this.market.collateral_token.decimals);
 
         const zapCalldata = buildCalldataForLeverageZapV2(router, calldata);
 
@@ -683,7 +694,7 @@ export class LeverageZapV2Module {
             _userCollateral,
             _debt,
             this.llamalend.constants.ALIASES.leverage_zap_v2,
-            [0, parseUnits(this._getMarketId(), 0), _userBorrowed],
+            [0, parseUnits(this._getMarketId(), 0), _userBorrowed, _minRecv],
             zapCalldata,
             { ...this.llamalend.constantOptions }
         );
@@ -696,7 +707,7 @@ export class LeverageZapV2Module {
             _userCollateral,
             _debt,
             this.llamalend.constants.ALIASES.leverage_zap_v2,
-            [0, parseUnits(this._getMarketId(), 0), _userBorrowed],
+            [0, parseUnits(this._getMarketId(), 0), _userBorrowed, _minRecv],
             zapCalldata,
             { ...this.llamalend.options, gasLimit }
         )).hash
@@ -716,28 +727,30 @@ export class LeverageZapV2Module {
         return await this.leverageCreateLoanApprove({ userCollateral, userBorrowed });
     }
 
-    public async leverageBorrowMoreEstimateGas({ userCollateral, userBorrowed, debt, router, calldata }: {
+    public async leverageBorrowMoreEstimateGas({ userCollateral, userBorrowed, debt, minRecv, router, calldata }: {
         userCollateral: TAmount,
         userBorrowed: TAmount,
         debt: TAmount,
+        minRecv: TAmount,
         router: string,
         calldata: string
     }): Promise<number> {
         this._checkLeverageZap();
         if (!(await this.leverageCreateLoanIsApproved({ userCollateral, userBorrowed }))) throw Error("Approval is needed for gas estimation");
-        return await this._leverageBorrowMore(userCollateral, userBorrowed, debt, router, calldata,  true) as number;
+        return await this._leverageBorrowMore(userCollateral, userBorrowed, debt, minRecv, router, calldata,  true) as number;
     }
 
-    public async leverageBorrowMore({ userCollateral, userBorrowed, debt, router, calldata }: {
+    public async leverageBorrowMore({ userCollateral, userBorrowed, debt, minRecv, router, calldata }: {
         userCollateral: TAmount,
         userBorrowed: TAmount,
         debt: TAmount,
+        minRecv: TAmount,
         router: string,
         calldata: string
     }): Promise<string> {
         this._checkLeverageZap();
         await this.leverageCreateLoanApprove({ userCollateral, userBorrowed });
-        return await this._leverageBorrowMore(userCollateral, userBorrowed, debt, router, calldata, false) as string;
+        return await this._leverageBorrowMore(userCollateral, userBorrowed, debt, minRecv, router, calldata, false) as string;
     }
 
     public async leverageBorrowMoreFutureLeverage({ userCollateral, userBorrowed, debt, quote, address = "" }: {
@@ -959,6 +972,7 @@ export class LeverageZapV2Module {
         stateCollateral: TAmount,
         userCollateral: TAmount,
         userBorrowed: TAmount,
+        minRecv: TAmount,
         router: string,
         calldata: string,
         estimateGas: boolean
@@ -967,6 +981,8 @@ export class LeverageZapV2Module {
         const _stateCollateral = parseUnits(stateCollateral, this.market.collateral_token.decimals);
         const _userCollateral = parseUnits(userCollateral, this.market.collateral_token.decimals);
         const _userBorrowed = parseUnits(userBorrowed, this.market.borrowed_token.decimals);
+        const _minRecv = parseUnits(minRecv, this.market.borrowed_token.decimals);
+
         let zapCalldata = buildCalldataForLeverageZapV2(router, "0x");
         if (_stateCollateral + _userCollateral > BigInt(0)) {
             zapCalldata = buildCalldataForLeverageZapV2(router, calldata)
@@ -975,7 +991,7 @@ export class LeverageZapV2Module {
         const contract = this.llamalend.contracts[this.market.addresses.controller].contract;
         const gas = await contract.repay_extended.estimateGas(
             this.llamalend.constants.ALIASES.leverage_zap_v2,
-            [0, parseUnits(this._getMarketId(), 0), _userCollateral, _userBorrowed],
+            [0, parseUnits(this._getMarketId(), 0), _userCollateral, _userBorrowed, _minRecv],
             zapCalldata
         );
         if (estimateGas) return smartNumber(gas);
@@ -985,34 +1001,36 @@ export class LeverageZapV2Module {
 
         return (await contract.repay_extended(
             this.llamalend.constants.ALIASES.leverage_zap_v2,
-            [0, parseUnits(this._getMarketId(), 0), _userCollateral, _userBorrowed],
+            [0, parseUnits(this._getMarketId(), 0), _userCollateral, _userBorrowed, _minRecv],
             zapCalldata,
             { ...this.llamalend.options, gasLimit }
         )).hash
     }
 
-    public async leverageRepayEstimateGas({ stateCollateral, userCollateral, userBorrowed, router, calldata }: {
+    public async leverageRepayEstimateGas({ stateCollateral, userCollateral, userBorrowed, minRecv, router, calldata }: {
         stateCollateral: TAmount,
         userCollateral: TAmount,
         userBorrowed: TAmount,
+        minRecv: TAmount,
         router: string,
         calldata: string
     }): Promise<number> {
         this._checkLeverageZap();
         if (!(await this.leverageRepayIsApproved({ userCollateral, userBorrowed }))) throw Error("Approval is needed for gas estimation");
-        return await this._leverageRepay(stateCollateral, userCollateral, userBorrowed, router, calldata, true) as number;
+        return await this._leverageRepay(stateCollateral, userCollateral, userBorrowed, minRecv, router, calldata, true) as number;
     }
 
-    public async leverageRepay({ stateCollateral, userCollateral, userBorrowed, router, calldata }: {
+    public async leverageRepay({ stateCollateral, userCollateral, userBorrowed, minRecv, router, calldata }: {
         stateCollateral: TAmount,
         userCollateral: TAmount,
         userBorrowed: TAmount,
+        minRecv: TAmount,
         router: string,
         calldata: string
     }): Promise<string> {
         this._checkLeverageZap();
         await this.leverageRepayApprove({ userCollateral, userBorrowed });
-        return await this._leverageRepay(stateCollateral, userCollateral, userBorrowed, router, calldata, false) as string;
+        return await this._leverageRepay(stateCollateral, userCollateral, userBorrowed, minRecv, router, calldata, false) as string;
     }
 
     public async leverageRepayFutureLeverage({ stateCollateral, userCollateral, userBorrowed, address = "" }: {


### PR DESCRIPTION
Execution methods (`createLoan`, `borrowMore`, `repay`) accept a `minRecv` parameter that guarantees the minimum amount of tokens received after the swap. This protects the user from slippage and frontrunning.