### PR TITLE
fix: v1 publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,6 +54,6 @@ jobs:
       - name: Publish main as latest
         if: github.ref_name == 'main'
         run: npm publish --tag latest
-      - name: Publish v1 branch as v1
+      - name: Publish v1 branch as legacy
         if: github.ref_name == 'v1'
-        run: npm publish --tag v1
+        run: npm publish --tag legacy


### PR DESCRIPTION
- we cannot use v1 because it's a valid semver, and [that's forbidden](https://docs.npmjs.com/cli/v11/commands/npm-dist-tag#caveats)