### PR TITLE
feat: add stats admin percentage

### DIFF
--- a/docs/SUPPORT_LLv2.md
+++ b/docs/SUPPORT_LLv2.md
@@ -143,6 +143,12 @@ This document tracks feature support across market versions.
 | ammBalances() | ✅ | ✅ | ✅ | ✅ | ✅ |
 | capAndAvailable() | ✅ | ✅ | ❌ | ✅ | ❌ |
 
+## Stats Module (`market.stats`) new methods
+| Method | v1 | v2 | Same logic | Same params | Same type |
+|--------|----|----|-----------------|----------------------|-----------------------|
+| adminPercentage() | ✅ | ✅ | ✅ | ✅ | ✅ |
+
+
 ---
 
 ## Wallet Module (`market.wallet`)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curvefi/llamalend-api",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "JavaScript library for Curve Lending",
   "main": "lib/index.js",
   "author": "Macket",

--- a/src/lendMarkets/LendMarketTemplate.ts
+++ b/src/lendMarkets/LendMarketTemplate.ts
@@ -166,17 +166,17 @@ export class LendMarketTemplate<V extends 'v1' | 'v2' = 'v1' | 'v2'> {
         }
 
         this.stats = {
-            parameters: stats.statsParameters.bind(this),
-            rates: stats.statsRates.bind(this),
-            futureRates: stats.statsFutureRates.bind(this),
-            balances: stats.statsBalances.bind(this),
-            bandsInfo: stats.statsBandsInfo.bind(this),
-            bandBalances: stats.statsBandBalances.bind(this),
-            bandsBalances: stats.statsBandsBalances.bind(this),
-            totalDebt: stats.statsTotalDebt.bind(this),
-            ammBalances: stats.statsAmmBalances.bind(this),
-            capAndAvailable: stats.statsCapAndAvailable.bind(this),
-            adminPercentage: stats.statsAdminPercentage.bind(this),
+            parameters: stats.statsParameters.bind(stats),
+            rates: stats.statsRates.bind(stats),
+            futureRates: stats.statsFutureRates.bind(stats),
+            balances: stats.statsBalances.bind(stats),
+            bandsInfo: stats.statsBandsInfo.bind(stats),
+            bandBalances: stats.statsBandBalances.bind(stats),
+            bandsBalances: stats.statsBandsBalances.bind(stats),
+            totalDebt: stats.statsTotalDebt.bind(stats),
+            ammBalances: stats.statsAmmBalances.bind(stats),
+            capAndAvailable: stats.statsCapAndAvailable.bind(stats),
+            adminPercentage: stats.statsAdminPercentage.bind(stats),
         } as StatsForVersion<V>
 
         this.wallet = {

--- a/src/lendMarkets/LendMarketTemplate.ts
+++ b/src/lendMarkets/LendMarketTemplate.ts
@@ -176,6 +176,7 @@ export class LendMarketTemplate<V extends 'v1' | 'v2' = 'v1' | 'v2'> {
             totalDebt: stats.statsTotalDebt.bind(this),
             ammBalances: stats.statsAmmBalances.bind(this),
             capAndAvailable: stats.statsCapAndAvailable.bind(this),
+            adminPercentage: stats.statsAdminPercentage.bind(this),
         } as StatsForVersion<V>
 
         this.wallet = {

--- a/src/lendMarkets/interfaces/v1/statsV1.ts
+++ b/src/lendMarkets/interfaces/v1/statsV1.ts
@@ -18,4 +18,5 @@ export interface IStatsV1 {
     totalDebt: (isGetter?: boolean, useAPI?: boolean) => Promise<string>,
     ammBalances: (isGetter?: boolean, useAPI?: boolean) => Promise<{ borrowed: string, collateral: string }>,
     capAndAvailable: (isGetter?: boolean, useAPI?: boolean) => Promise<{ cap: string, available: string }>,
+    adminPercentage: () => Promise<string>,
 }

--- a/src/lendMarkets/interfaces/v2/statsV2.ts
+++ b/src/lendMarkets/interfaces/v2/statsV2.ts
@@ -18,4 +18,5 @@ export interface IStatsV2 {
     totalDebt: (isGetter?: boolean, useAPI?: boolean) => Promise<string>,
     ammBalances: (isGetter?: boolean, useAPI?: boolean) => Promise<{ borrowed: string, collateral: string }>,
     capAndAvailable: (isGetter?: boolean, useAPI?: boolean) => Promise<{ cap: string, available: string }>,
+    adminPercentage: () => Promise<string>,
 }

--- a/src/lendMarkets/modules/common/statsBase.ts
+++ b/src/lendMarkets/modules/common/statsBase.ts
@@ -3,7 +3,6 @@ import {TAmount} from "../../../interfaces";
 import type { LendMarketTemplate } from "../../LendMarketTemplate";
 import {
     parseUnits,
-    BN,
     toBN,
     formatUnits,
     formatNumber,
@@ -11,10 +10,14 @@ import {
 import {Llamalend} from "../../../llamalend";
 import {_getMarketsData} from "../../../external-api";
 import {cacheKey, cacheStats} from "../../../cache";
+import { computeRatesFromRate, fetchMarketDataByVault } from "../../utils";
 
-export class StatsBaseModule {
+export abstract class StatsBaseModule {
     protected market: LendMarketTemplate;
     protected llamalend: Llamalend;
+
+    protected abstract _getRate(isGetter: boolean): Promise<bigint>;
+    protected abstract _getFutureRate(_dReserves: bigint, _dDebt: bigint): Promise<bigint>;
 
     constructor(market: LendMarketTemplate) {
         this.market = market;
@@ -53,55 +56,24 @@ export class StatsBaseModule {
         maxAge: 5 * 60 * 1000, // 5m
     });
 
-    private _getRate = async (isGetter = true): Promise<bigint> => {
-        let _rate;
-        if(isGetter) {
-            _rate = cacheStats.get(cacheKey(this.market.addresses.amm, 'rate'));
-        } else {
-            _rate = await this.llamalend.contracts[this.market.addresses.amm].contract.rate(this.llamalend.constantOptions);
-            cacheStats.set(cacheKey(this.market.addresses.controller, 'rate'), _rate);
-        }
-        return _rate;
-    }
-
-    private _getFutureRate = async (_dReserves: bigint, _dDebt: bigint): Promise<bigint> => {
-        const mpContract = this.llamalend.contracts[this.market.addresses.monetary_policy].contract;
-        return await mpContract.future_rate(this.market.addresses.controller, _dReserves, _dDebt);
-    }
-
     public async statsRates(isGetter = true, useAPI = false): Promise<{borrowApr: string, lendApr: string, borrowApy: string, lendApy: string}> {
         if(useAPI) {
-            const response = await _getMarketsData(this.llamalend.constants.NETWORK_NAME);
-
-            const market = response.lendingVaultData.find((item) => item.address.toLowerCase() === this.market.addresses.vault.toLowerCase())
-
-            if(market) {
-                return {
-                    borrowApr: (market.rates.borrowApr * 100).toString(),
-                    lendApr: (market.rates.lendApr * 100).toString(),
-                    borrowApy: (market.rates.borrowApy * 100).toString(),
-                    lendApy: (market.rates.lendApy * 100).toString(),
-                }
-            } else {
-                throw new Error('Market not found in API')
-            }
+            const market = await fetchMarketDataByVault(
+                this.llamalend.constants.NETWORK_NAME,
+                this.market.addresses.vault,
+                _getMarketsData
+            );
+            return {
+                borrowApr: (market.rates.borrowApr * 100).toString(),
+                lendApr: (market.rates.lendApr * 100).toString(),
+                borrowApy: (market.rates.borrowApy * 100).toString(),
+                lendApy: (market.rates.lendApy * 100).toString(),
+            };
         } else {
             const _rate = await this._getRate(isGetter);
-            const borrowApr =  toBN(_rate).times(365).times(86400).times(100).toString();
-            // borrowApy = e**(rate*365*86400) - 1
-            const borrowApy = String(((2.718281828459 ** (toBN(_rate).times(365).times(86400)).toNumber()) - 1) * 100);
-            let lendApr = "0";
-            let lendApy = "0";
             const debt = await this.statsTotalDebt(isGetter);
-            if (Number(debt) > 0) {
-                const { cap } = await this.statsCapAndAvailable(isGetter);
-                lendApr = toBN(_rate).times(365).times(86400).times(debt).div(cap).times(100).toString();
-                // lendApy = (debt * e**(rate*365*86400) - debt) / cap
-                const debtInAYearBN = BN(debt).times(2.718281828459 ** (toBN(_rate).times(365).times(86400)).toNumber());
-                lendApy = debtInAYearBN.minus(debt).div(cap).times(100).toString();
-            }
-
-            return { borrowApr, lendApr, borrowApy, lendApy }
+            const { cap } = Number(debt) > 0 ? await this.statsCapAndAvailable(isGetter) : { cap: "0" };
+            return computeRatesFromRate(_rate, debt, cap);
         }
     }
 
@@ -109,21 +81,9 @@ export class StatsBaseModule {
         const _dReserves = parseUnits(dReserves, this.market.borrowed_token.decimals);
         const _dDebt = parseUnits(dDebt, this.market.borrowed_token.decimals);
         const _rate = await this._getFutureRate(_dReserves, _dDebt);
-        const borrowApr =  toBN(_rate).times(365).times(86400).times(100).toString();
-        // borrowApy = e**(rate*365*86400) - 1
-        const borrowApy = String(((2.718281828459 ** (toBN(_rate).times(365).times(86400)).toNumber()) - 1) * 100);
-        let lendApr = "0";
-        let lendApy = "0";
         const debt = Number(await this.statsTotalDebt()) + Number(dDebt);
-        if (Number(debt) > 0) {
-            const cap = Number((await this.statsCapAndAvailable(true, useAPI)).cap) + Number(dReserves);
-            lendApr = toBN(_rate).times(365).times(86400).times(debt).div(cap).times(100).toString();
-            // lendApy = (debt * e**(rate*365*86400) - debt) / cap
-            const debtInAYearBN = BN(debt).times(2.718281828459 ** (toBN(_rate).times(365).times(86400)).toNumber());
-            lendApy = debtInAYearBN.minus(debt).div(cap).times(100).toString();
-        }
-
-        return { borrowApr, lendApr, borrowApy, lendApy }
+        const cap = Number((await this.statsCapAndAvailable(true, useAPI)).cap) + Number(dReserves);
+        return computeRatesFromRate(_rate, debt, cap);
     }
 
     public async statsBalances(): Promise<[string, string]> {
@@ -202,15 +162,12 @@ export class StatsBaseModule {
 
     public async statsTotalDebt(isGetter = true, useAPI = true): Promise<string> {
         if(useAPI) {
-            const response = await _getMarketsData(this.llamalend.constants.NETWORK_NAME);
-
-            const market = response.lendingVaultData.find((item) => item.address.toLowerCase() === this.market.addresses.vault.toLowerCase())
-
-            if(market) {
-                return market.borrowed.total.toString();
-            } else {
-                throw new Error('Market not found in API')
-            }
+            const market = await fetchMarketDataByVault(
+                this.llamalend.constants.NETWORK_NAME,
+                this.market.addresses.vault,
+                _getMarketsData
+            );
+            return market.borrowed.total.toString();
         } else {
             let _debt;
             if(isGetter) {
@@ -226,18 +183,15 @@ export class StatsBaseModule {
 
     public statsAmmBalances = async (isGetter = true, useAPI = false): Promise<{ borrowed: string, collateral: string }> => {
         if(useAPI) {
-            const response = await _getMarketsData(this.llamalend.constants.NETWORK_NAME);
-
-            const market = response.lendingVaultData.find((item) => item.address.toLowerCase() === this.market.addresses.vault.toLowerCase())
-
-            if(market) {
-                return {
-                    borrowed: market.ammBalances.ammBalanceBorrowed.toString(),
-                    collateral: market.ammBalances.ammBalanceCollateral.toString(),
-                }
-            } else {
-                throw new Error('Market not found in API')
-            }
+            const market = await fetchMarketDataByVault(
+                this.llamalend.constants.NETWORK_NAME,
+                this.market.addresses.vault,
+                _getMarketsData
+            );
+            return {
+                borrowed: market.ammBalances.ammBalanceBorrowed.toString(),
+                collateral: market.ammBalances.ammBalanceCollateral.toString(),
+            };
         } else {
             const borrowedContract = this.llamalend.contracts[this.market.addresses.borrowed_token].multicallContract;
             const collateralContract = this.llamalend.contracts[this.market.addresses.collateral_token].multicallContract;
@@ -273,18 +227,15 @@ export class StatsBaseModule {
 
     public async statsCapAndAvailable(isGetter = true, useAPI = false): Promise<{ cap: string, available: string }> {
         if(useAPI) {
-            const response = await _getMarketsData(this.llamalend.constants.NETWORK_NAME);
-
-            const market = response.lendingVaultData.find((item) => item.address.toLowerCase() === this.market.addresses.vault.toLowerCase())
-
-            if(market) {
-                return {
-                    cap: market.totalSupplied.total.toString(),
-                    available: market.availableToBorrow.total.toString(),
-                }
-            } else {
-                throw new Error('Market not found in API')
-            }
+            const market = await fetchMarketDataByVault(
+                this.llamalend.constants.NETWORK_NAME,
+                this.market.addresses.vault,
+                _getMarketsData
+            );
+            return {
+                cap: market.totalSupplied.total.toString(),
+                available: market.availableToBorrow.total.toString(),
+            };
         } else {
             const vaultContract = this.llamalend.contracts[this.market.addresses.vault].multicallContract;
             const borrowedContract = this.llamalend.contracts[this.market.addresses.borrowed_token].multicallContract;

--- a/src/lendMarkets/modules/common/statsBase.ts
+++ b/src/lendMarkets/modules/common/statsBase.ts
@@ -11,17 +11,43 @@ import {Llamalend} from "../../../llamalend";
 import {_getMarketsData} from "../../../external-api";
 import {cacheKey, cacheStats} from "../../../cache";
 import { computeRatesFromRate, fetchMarketDataByVault } from "../../utils";
+const PRECISION = BigInt("1000000000000000000"); // 1e18
 
-export abstract class StatsBaseModule {
+export class StatsBaseModule {
     protected market: LendMarketTemplate;
     protected llamalend: Llamalend;
-
-    protected abstract _getRate(isGetter: boolean): Promise<bigint>;
-    protected abstract _getFutureRate(_dReserves: bigint, _dDebt: bigint): Promise<bigint>;
 
     constructor(market: LendMarketTemplate) {
         this.market = market;
         this.llamalend = market.getLlamalend();
+    }
+
+    protected _fetchAdminPercentage = async (): Promise<bigint> => {
+        return BigInt(0)
+    }
+
+    private _getRate = async (isGetter = true): Promise<bigint> => {
+        if (isGetter) {
+            const _rate: bigint = cacheStats.get(cacheKey(this.market.addresses.amm, 'rate'));
+            const _adminPercentage = await this._fetchAdminPercentage();
+            return _rate * (PRECISION - _adminPercentage) / PRECISION;
+        } else {
+            const [_rate, _adminPercentage] = await Promise.all([
+                this.llamalend.contracts[this.market.addresses.amm].contract.rate(this.llamalend.constantOptions),
+                this._fetchAdminPercentage(),
+            ]);
+            cacheStats.set(cacheKey(this.market.addresses.controller, 'rate'), _rate);
+            return _rate * (PRECISION - _adminPercentage) / PRECISION;
+        }
+    }
+
+    private _getFutureRate = async (_dReserves: bigint, _dDebt: bigint): Promise<bigint> => {
+        const mpContract = this.llamalend.contracts[this.market.addresses.monetary_policy].contract;
+        const [_rate, _adminPercentage] = await Promise.all([
+            mpContract.future_rate(this.market.addresses.controller, _dReserves, _dDebt),
+            this._fetchAdminPercentage(),
+        ]);
+        return _rate * (PRECISION - _adminPercentage) / PRECISION;
     }
 
     public statsParameters = memoize(async (): Promise<{
@@ -260,5 +286,10 @@ export abstract class StatsBaseModule {
             // cap -> totalAssets
             // add cap: controller.borrow_cap() // Display
         }
+    }
+
+    public statsAdminPercentage = async (): Promise<string> => {
+        const _adminPercentage = await this._fetchAdminPercentage();
+        return formatUnits(_adminPercentage * BigInt(100));
     }
 }

--- a/src/lendMarkets/modules/v1/statsV1.ts
+++ b/src/lendMarkets/modules/v1/statsV1.ts
@@ -1,24 +1,3 @@
 import { StatsBaseModule } from "../common/statsBase.js";
-import {cacheKey, cacheStats} from "../../../cache";
 
-export class StatsV1Module extends StatsBaseModule {
-    public statsAdminPercentage = async (): Promise<string> => {
-        return "0";
-    } 
-
-    protected override _getRate = async (isGetter = true): Promise<bigint> => {
-        let _rate;
-        if(isGetter) {
-            _rate = cacheStats.get(cacheKey(this.market.addresses.amm, 'rate'));
-        } else {
-            _rate = await this.llamalend.contracts[this.market.addresses.amm].contract.rate(this.llamalend.constantOptions);
-            cacheStats.set(cacheKey(this.market.addresses.controller, 'rate'), _rate);
-        }
-        return _rate;
-    }
-
-    protected override _getFutureRate = async (_dReserves: bigint, _dDebt: bigint): Promise<bigint> => {
-        const mpContract = this.llamalend.contracts[this.market.addresses.monetary_policy].contract;
-        return await mpContract.future_rate(this.market.addresses.controller, _dReserves, _dDebt);
-    }
-}
+export class StatsV1Module extends StatsBaseModule {}

--- a/src/lendMarkets/modules/v1/statsV1.ts
+++ b/src/lendMarkets/modules/v1/statsV1.ts
@@ -1,3 +1,24 @@
 import { StatsBaseModule } from "../common/statsBase.js";
+import {cacheKey, cacheStats} from "../../../cache";
 
-export class StatsV1Module extends StatsBaseModule {}
+export class StatsV1Module extends StatsBaseModule {
+    public statsAdminPercentage = async (): Promise<string> => {
+        return "0";
+    } 
+
+    protected override _getRate = async (isGetter = true): Promise<bigint> => {
+        let _rate;
+        if(isGetter) {
+            _rate = cacheStats.get(cacheKey(this.market.addresses.amm, 'rate'));
+        } else {
+            _rate = await this.llamalend.contracts[this.market.addresses.amm].contract.rate(this.llamalend.constantOptions);
+            cacheStats.set(cacheKey(this.market.addresses.controller, 'rate'), _rate);
+        }
+        return _rate;
+    }
+
+    protected override _getFutureRate = async (_dReserves: bigint, _dDebt: bigint): Promise<bigint> => {
+        const mpContract = this.llamalend.contracts[this.market.addresses.monetary_policy].contract;
+        return await mpContract.future_rate(this.market.addresses.controller, _dReserves, _dDebt);
+    }
+}

--- a/src/lendMarkets/modules/v2/statsV2.ts
+++ b/src/lendMarkets/modules/v2/statsV2.ts
@@ -1,3 +1,39 @@
+import memoize from "memoizee";
 import { StatsBaseModule } from "../common/statsBase.js";
+import {cacheKey, cacheStats} from "../../../cache";
+import { formatUnits } from "../../../utils";
 
-export class StatsV2Module extends StatsBaseModule {}
+const PRECISION = BigInt("1000000000000000000"); // 1e18
+
+export class StatsV2Module extends StatsBaseModule {
+    private _fetchAdminPercentage = memoize(async (): Promise<bigint> => {
+        return await this.llamalend.contracts[this.market.addresses.controller].contract.admin_percentage(this.llamalend.constantOptions);
+    }, {
+        promise: true,
+        maxAge: 30 * 60 * 1000, // 30m
+    });
+
+    public statsAdminPercentage = async (): Promise<string> => {
+        const _adminPercentage = await this._fetchAdminPercentage();
+        return formatUnits(_adminPercentage * BigInt(100));
+    }
+
+    protected override _getRate = async (isGetter = true): Promise<bigint> => {
+        let _rate: bigint;
+        if (isGetter) {
+            _rate = cacheStats.get(cacheKey(this.market.addresses.amm, 'rate'));
+        } else {
+            _rate = await this.llamalend.contracts[this.market.addresses.amm].contract.rate(this.llamalend.constantOptions);
+            cacheStats.set(cacheKey(this.market.addresses.controller, 'rate'), _rate);
+        }
+        const _adminPercentage = await this._fetchAdminPercentage();
+        return _rate * (PRECISION - _adminPercentage) / PRECISION;
+    }
+
+    protected override _getFutureRate = async (_dReserves: bigint, _dDebt: bigint): Promise<bigint> => {
+        const mpContract = this.llamalend.contracts[this.market.addresses.monetary_policy].contract;
+        const _rate = await mpContract.future_rate(this.market.addresses.controller, _dReserves, _dDebt);
+        const _adminPercentage = await this._fetchAdminPercentage();
+        return _rate * (PRECISION - _adminPercentage) / PRECISION;
+    }
+}

--- a/src/lendMarkets/modules/v2/statsV2.ts
+++ b/src/lendMarkets/modules/v2/statsV2.ts
@@ -1,39 +1,11 @@
 import memoize from "memoizee";
 import { StatsBaseModule } from "../common/statsBase.js";
-import {cacheKey, cacheStats} from "../../../cache";
-import { formatUnits } from "../../../utils";
-
-const PRECISION = BigInt("1000000000000000000"); // 1e18
 
 export class StatsV2Module extends StatsBaseModule {
-    private _fetchAdminPercentage = memoize(async (): Promise<bigint> => {
+    protected _fetchAdminPercentage = memoize(async (): Promise<bigint> => {
         return await this.llamalend.contracts[this.market.addresses.controller].contract.admin_percentage(this.llamalend.constantOptions);
     }, {
         promise: true,
         maxAge: 30 * 60 * 1000, // 30m
     });
-
-    public statsAdminPercentage = async (): Promise<string> => {
-        const _adminPercentage = await this._fetchAdminPercentage();
-        return formatUnits(_adminPercentage * BigInt(100));
-    }
-
-    protected override _getRate = async (isGetter = true): Promise<bigint> => {
-        let _rate: bigint;
-        if (isGetter) {
-            _rate = cacheStats.get(cacheKey(this.market.addresses.amm, 'rate'));
-        } else {
-            _rate = await this.llamalend.contracts[this.market.addresses.amm].contract.rate(this.llamalend.constantOptions);
-            cacheStats.set(cacheKey(this.market.addresses.controller, 'rate'), _rate);
-        }
-        const _adminPercentage = await this._fetchAdminPercentage();
-        return _rate * (PRECISION - _adminPercentage) / PRECISION;
-    }
-
-    protected override _getFutureRate = async (_dReserves: bigint, _dDebt: bigint): Promise<bigint> => {
-        const mpContract = this.llamalend.contracts[this.market.addresses.monetary_policy].contract;
-        const _rate = await mpContract.future_rate(this.market.addresses.controller, _dReserves, _dDebt);
-        const _adminPercentage = await this._fetchAdminPercentage();
-        return _rate * (PRECISION - _adminPercentage) / PRECISION;
-    }
 }

--- a/src/lendMarkets/utils.ts
+++ b/src/lendMarkets/utils.ts
@@ -1,0 +1,49 @@
+import { BN, toBN } from "../utils";
+import { INetworkName, IMarketData, IMarketDataAPI } from "../interfaces";
+
+export type RatesResult = {
+    borrowApr: string;
+    lendApr: string;
+    borrowApy: string;
+    lendApy: string;
+};
+
+/**
+ * Computes borrow/lend APR and APY from a raw per-second rate and current debt/cap.
+ * borrowApy = e^(rate * 365 * 86400) - 1
+ * lendApy   = (debt * e^(rate * 365 * 86400) - debt) / cap
+ */
+export const computeRatesFromRate = (
+    _rate: bigint,
+    debt: string | number,
+    cap: string | number
+): RatesResult => {
+    const annualFactor = toBN(_rate).times(365).times(86400);
+    const expFactor = Math.E ** annualFactor.toNumber();
+
+    const borrowApr = annualFactor.times(100).toString();
+    const borrowApy = String((expFactor - 1) * 100);
+
+    let lendApr = "0";
+    let lendApy = "0";
+
+    if (Number(debt) > 0) {
+        lendApr = annualFactor.times(debt).div(cap).times(100).toString();
+        lendApy = BN(debt).times(expFactor).minus(debt).div(cap).times(100).toString();
+    }
+
+    return { borrowApr, lendApr, borrowApy, lendApy };
+}
+
+export const fetchMarketDataByVault = async (
+    networkName: INetworkName,
+    vaultAddress: string,
+    getData: (network: INetworkName) => Promise<IMarketData>
+): Promise<IMarketDataAPI> => {
+    const response = await getData(networkName);
+    const market = response.lendingVaultData.find(
+        (item) => item.address.toLowerCase() === vaultAddress.toLowerCase()
+    );
+    if (!market) throw new Error("Market not found in API");
+    return market;
+}

--- a/src/lendMarkets/utils.ts
+++ b/src/lendMarkets/utils.ts
@@ -24,13 +24,8 @@ export const computeRatesFromRate = (
     const borrowApr = annualFactor.times(100).toString();
     const borrowApy = String((expFactor - 1) * 100);
 
-    let lendApr = "0";
-    let lendApy = "0";
-
-    if (Number(debt) > 0) {
-        lendApr = annualFactor.times(debt).div(cap).times(100).toString();
-        lendApy = BN(debt).times(expFactor).minus(debt).div(cap).times(100).toString();
-    }
+    const lendApr = annualFactor.times(debt).div(cap).times(100).toString();
+    const lendApy = BN(debt).times(expFactor).minus(debt).div(cap).times(100).toString();
 
     return { borrowApr, lendApr, borrowApy, lendApy };
 }


### PR DESCRIPTION

1. Add the method calling controller.admin_percentage() to get % (1e18 == 100%) and returning the formatted result.

2. The rate has to be adjusted for lend APR/APY: adjusted_rate = rate * (1e18 - controller.admin_percentage()) / 1e18 (don’t do that for borrow APR/APY).