### PR TITLE
Fix/fixed liquidate for llv2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curvefi/llamalend-api",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "description": "JavaScript library for Curve Lending",
   "main": "lib/index.js",
   "author": "Macket",

--- a/src/constants/abis/ControllerV2.json
+++ b/src/constants/abis/ControllerV2.json
@@ -671,78 +671,6 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "name": "_user",
-        "type": "address"
-      },
-      {
-        "name": "_min_x",
-        "type": "uint256"
-      },
-      {
-        "name": "_frac",
-        "type": "uint256"
-      }
-    ],
-    "name": "liquidate",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "name": "_user",
-        "type": "address"
-      },
-      {
-        "name": "_min_x",
-        "type": "uint256"
-      },
-      {
-        "name": "_frac",
-        "type": "uint256"
-      },
-      {
-        "name": "_callbacker",
-        "type": "address"
-      }
-    ],
-    "name": "liquidate",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "name": "_user",
-        "type": "address"
-      },
-      {
-        "name": "_min_x",
-        "type": "uint256"
-      },
-      {
-        "name": "_frac",
-        "type": "uint256"
-      },
-      {
-        "name": "_callbacker",
-        "type": "address"
-      },
-      {
-        "name": "_calldata",
-        "type": "bytes"
-      }
-    ],
-    "name": "liquidate",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
     "inputs": [],
     "name": "save_rate",
     "outputs": [],
@@ -1251,27 +1179,6 @@
       {
         "name": "_user",
         "type": "address"
-      }
-    ],
-    "name": "tokens_to_liquidate",
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "name": "_user",
-        "type": "address"
-      },
-      {
-        "name": "_frac",
-        "type": "uint256"
       }
     ],
     "name": "tokens_to_liquidate",


### PR DESCRIPTION
Fix error  when liquidate for llv2 
ambiguous function description (i.e. matches "tokens_to_liquidate(address)", "tokens_to_liquidate(address,uint256)") (argument="key", value="tokens_to_liquidate", code=INVALID_ARGUMENT, version=6.16.0)"