### PR TITLE
fix: fixed llv2 repay decimals

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curvefi/llamalend-api",
-  "version": "2.0.27",
+  "version": "2.0.28",
   "description": "JavaScript library for Curve Lending",
   "main": "lib/index.js",
   "author": "Macket",

--- a/src/lendMarkets/modules/common/loanBase.ts
+++ b/src/lendMarkets/modules/common/loanBase.ts
@@ -431,7 +431,7 @@ export abstract class LoanBaseModule {
         const { debt: currentDebt } = await this.market.userPosition.userState(address);
         if (Number(currentDebt) === 0) throw Error(`Loan for ${address} does not exist`);
 
-        const _debt = parseUnits(debt);
+        const _debt = parseUnits(debt, this.market.borrowed_token.decimals);
         const [, n1] = await this.market.userPosition.userBands(address);
         const { borrowed } = await this.market.userPosition.userState(address);
         const n = (BN(borrowed).gt(0)) ? MAX_ACTIVE_BAND : n1 - 1;

--- a/src/lendMarkets/modules/v1/loanV1.ts
+++ b/src/lendMarkets/modules/v1/loanV1.ts
@@ -168,7 +168,7 @@ export class LoanV1Module extends LoanBaseModule implements ILoanV1 {
 
     public async repayHealth({ debt, full = true, address = "" }: { debt: number | string; full?: boolean; address?: string }): Promise<string> {
         address = _getAddress.call(this.llamalend, address);
-        const _debt = parseUnits(debt) * BigInt(-1);
+        const _debt = parseUnits(debt, this.market.borrowed_token.decimals) * BigInt(-1);
 
         const contract = this.llamalend.contracts[this.market.addresses.controller].contract;
         const _health = await contract.health_calculator(address, 0, _debt, full, 0, this.llamalend.constantOptions) as bigint;

--- a/src/lendMarkets/modules/v2/loanV2.ts
+++ b/src/lendMarkets/modules/v2/loanV2.ts
@@ -64,7 +64,7 @@ export class LoanV2Module extends LoanBaseModule implements ILoanV2 {
 
     public async repayHealth({ debt, shrink = false, full = true, address = "" }: { debt: number | string; shrink?: boolean; full?: boolean; address?: string }): Promise<string> {
         address = _getAddress.call(this.llamalend, address);
-        const _debt = parseUnits(debt);
+        const _debt = parseUnits(debt, this.market.borrowed_token.decimals);
 
         const contract = this.llamalend.contracts[this.market.addresses.controller].contract;
         const _health = await contract.repay_health_preview(0, _debt, address, shrink, full, this.llamalend.constantOptions) as bigint;


### PR DESCRIPTION
Added borrowed token decimals for debt into repay methods. Also checked other methods.