### PR TITLE
fix: missing user address in repayBands method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@curvefi/llamalend-api",
-  "version": "2.0.16",
+  "version": "2.0.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@curvefi/llamalend-api",
-      "version": "2.0.16",
+      "version": "2.0.29",
       "license": "MIT",
       "dependencies": {
         "@curvefi/ethcall": "6.0.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curvefi/llamalend-api",
-  "version": "2.0.28",
+  "version": "2.0.29",
   "description": "JavaScript library for Curve Lending",
   "main": "lib/index.js",
   "author": "Macket",

--- a/src/mintMarkets/MintMarketTemplate.ts
+++ b/src/mintMarkets/MintMarketTemplate.ts
@@ -1136,6 +1136,7 @@ export class MintMarketTemplate {
     // ---------------- REPAY ----------------
 
     private async _repayBands(debt: number | string, address: string): Promise<[bigint, bigint]> {
+        address = _getAddress.call(this.llamalend, address);
         const { _collateral: _currentCollateral, _debt: _currentDebt, _stablecoin: _currentStablecoin } = await this._userState(address);
         if (_currentDebt === BigInt(0)) throw Error(`Loan for ${address} does not exist`);
 


### PR DESCRIPTION
- fixes error `UNCONFIGURED_NAME` when trying to calculate repay liquidation range in old mint markets