### PR TITLE
fix: json import type annotation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@curvefi/llamalend-api",
-  "version": "2.0.29",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@curvefi/llamalend-api",
-      "version": "2.0.29",
+      "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
         "@curvefi/ethcall": "6.0.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curvefi/llamalend-api",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "JavaScript library for Curve Lending",
   "main": "lib/index.js",
   "author": "Macket",

--- a/src/mintMarkets/fetch/fetchMintMarkets.ts
+++ b/src/mintMarkets/fetch/fetchMintMarkets.ts
@@ -3,7 +3,7 @@ import { _getCrvUsdMarketsData } from "../../external-api.js";
 import ERC20ABI from '../../constants/abis/ERC20.json' with {type: 'json'};
 import llammaABI from "../../constants/abis/crvUSD/llamma.json" with {type: 'json'};
 import controllerABI from "../../constants/abis/crvUSD/controller.json" with {type: 'json'};
-import controllerV2ABI from "../../constants/abis/crvUSD/controller_v2.json";
+import controllerV2ABI from "../../constants/abis/crvUSD/controller_v2.json" with {type: 'json'};
 import FactoryABI from "../../constants/abis/crvUSD/Factory.json" with {type: 'json'};
 import {extractDecimals} from "../../constants/utils.js";
 import {handleMultiCallResponse} from "../../utils.js";


### PR DESCRIPTION
Fixes the warning `Module "../../node_modules/@curvefi/llamalend-api/lib/mintMarkets/fetch/fetchMintMarkets.js" tried to import "../../node_modules/@curvefi/llamalend-api/lib/constants/abis/crvUSD/controller_v2.json" with no attributes, but it was already imported elsewhere with "type": "json" attributes. Please ensure that import attributes for the same module are always consistent.`