### PR TITLE
feat: add gauges for llv2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curvefi/llamalend-api",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "JavaScript library for Curve Lending",
   "main": "lib/index.js",
   "author": "Macket",

--- a/src/lendMarkets/fetch/fetchFactoryData.ts
+++ b/src/lendMarkets/fetch/fetchFactoryData.ts
@@ -112,10 +112,9 @@ export const getFactoryMarketDataV2 = async (llamalend: Llamalend) => {
     const gaugeFactoryAddress = llamalend.constants.ALIASES.gauge_factory;
     if (llamalend.chainId !== 1 && gaugeFactoryAddress && gaugeFactoryAddress !== llamalend.constants.ZERO_ADDRESS) {
         const gaugeFactory = llamalend.contracts[gaugeFactoryAddress];
-        const fetchedGauges = (await llamalend.multicallProvider.all(
+        (await llamalend.multicallProvider.all(
             vaults.map((vault: string) => createCall(gaugeFactory, "get_gauge_from_lp_token", [vault]))
-        ) as string[]).map((address) => address.toLowerCase());
-        fetchedGauges.forEach((gauge, i) => { gauges[i] = gauge; });
+        ) as string[]).forEach((gauge, i) => { gauges[i] = gauge.toLowerCase(); });
     }
 
     return {

--- a/src/lendMarkets/fetch/fetchFactoryData.ts
+++ b/src/lendMarkets/fetch/fetchFactoryData.ts
@@ -95,7 +95,7 @@ export const getFactoryMarketDataV2 = async (llamalend: Llamalend) => {
     const collateral_tokens: string[] = [];
     const borrowed_tokens: string[] = [];
     const monetary_policies: string[] = [];
-    const gauges: string[] = [];
+    const gauges: string[] = new Array(Number(markets_count)).fill(llamalend.constants.ZERO_ADDRESS);
 
     for (let i = 0; i < markets_count; i++) {
         const marketData = res[i] as any;
@@ -107,7 +107,15 @@ export const getFactoryMarketDataV2 = async (llamalend: Llamalend) => {
         borrowed_tokens.push(marketData[4].toLowerCase());
         monetary_policies.push(marketData[6].toLowerCase());
         names.push(''); // new factory does not give names, it's generated at the market creation level
-        gauges.push(llamalend.constants.ZERO_ADDRESS);
+    }
+
+    const gaugeFactoryAddress = llamalend.constants.ALIASES.gauge_factory;
+    if (llamalend.chainId !== 1 && gaugeFactoryAddress && gaugeFactoryAddress !== llamalend.constants.ZERO_ADDRESS) {
+        const gaugeFactory = llamalend.contracts[gaugeFactoryAddress];
+        const fetchedGauges = (await llamalend.multicallProvider.all(
+            vaults.map((vault: string) => createCall(gaugeFactory, "get_gauge_from_lp_token", [vault]))
+        ) as string[]).map((address) => address.toLowerCase());
+        fetchedGauges.forEach((gauge, i) => { gauges[i] = gauge; });
     }
 
     return {

--- a/src/lendMarkets/fetch/fetchFactoryData.ts
+++ b/src/lendMarkets/fetch/fetchFactoryData.ts
@@ -109,6 +109,7 @@ export const getFactoryMarketDataV2 = async (llamalend: Llamalend) => {
         names.push(''); // new factory does not give names, it's generated at the market creation level
     }
 
+    // Fetch gauges for non-mainnet chains. Mainnet will use the new approach of fetching gauges from the new factory.
     const gaugeFactoryAddress = llamalend.constants.ALIASES.gauge_factory;
     if (llamalend.chainId !== 1 && gaugeFactoryAddress && gaugeFactoryAddress !== llamalend.constants.ZERO_ADDRESS) {
         const gaugeFactory = llamalend.contracts[gaugeFactoryAddress];


### PR DESCRIPTION
The current solution covers all networks except Ethereum mainnet.

For mainnet, we'll implement a separate solution with a different approach based on gauges.
