### PR TITLE
fix: fixed crvAPY for llv2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curvefi/llamalend-api",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "JavaScript library for Curve Lending",
   "main": "lib/index.js",
   "author": "Macket",

--- a/src/lendMarkets/modules/common/vault.ts
+++ b/src/lendMarkets/modules/common/vault.ts
@@ -289,14 +289,15 @@ export class VaultModule {
     }
 
     public async vaultTotalLiquidity(useAPI = true): Promise<string> {
-        const { totalAssets } = await this.market.stats.capAndAvailable(true, useAPI);
+        const { totalAssets } = await this.market.stats.capAndAvailable(false, useAPI);
         const price = await _getUsdRate.call(this.llamalend, this.market.addresses.borrowed_token);
 
         return BN(totalAssets).times(price).toFixed(6)
     }
 
     private _calcCrvApr = async (futureWorkingSupplyBN: BigNumber | null = null): Promise<[baseApy: number, boostedApy: number]> => {
-        const totalLiquidityUSD = await this.vaultTotalLiquidity();
+        const totalLiquidityUSD = await this.vaultTotalLiquidity(false);
+        
         if (Number(totalLiquidityUSD) === 0) return [0, 0];
 
         let inflationRateBN, workingSupplyBN, totalSupplyBN;


### PR DESCRIPTION
Disabled the outdated isGetter logic. Also disabled fetching by API. Will enable API after switch API to prices