### PR TITLE
chore: remove userBorrowed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1051,7 +1051,7 @@ Use `calcMinRecv(expected, slippage)` to compute the minimum acceptable amount:
 ```ts
 // quote.outAmount — the expected amount from your router (computed on your side)
 const minRecv = lendMarket.leverageZapV2.calcMinRecv(quote.outAmount, 0.5); // 0.5% slippage
-await lendMarket.leverageZapV2.createLoan({ userCollateral, userBorrowed, debt, range, minRecv, router, calldata });
+await lendMarket.leverageZapV2.createLoan({ userCollateral, debt, range, minRecv, router, calldata });
 ```
 
 
@@ -1089,7 +1089,7 @@ await lendMarket.leverageZapV2.createLoan({ userCollateral, userBorrowed, debt, 
     // 7.4728229145282742179
     
     // Get maximum possible debt for given parameters
-    await lendMarket.leverageZapV2.createLoanMaxRecv({ userCollateral, userBorrowed, range, getExpected });
+    await lendMarket.leverageZapV2.createLoanMaxRecv({ userCollateral, range, getExpected });
     // {
     //     maxDebt: '26089.494406081862861214',
     //     maxTotalCollateral: '9.539182089833411347',
@@ -1103,7 +1103,7 @@ await lendMarket.leverageZapV2.createLoan({ userCollateral, userBorrowed, debt, 
     // Get quote for swapping (debt + userBorrowed)!!!
     
     // Get expected collateral amount
-    await lendMarket.leverageZapV2.createLoanExpectedCollateral({ userCollateral, userBorrowed, debt, quote });
+    await lendMarket.leverageZapV2.createLoanExpectedCollateral({ userCollateral, debt, quote });
     // {
     //     totalCollateral: '1.946422996710829',
     //     userCollateral: '1.0',
@@ -1115,8 +1115,7 @@ await lendMarket.leverageZapV2.createLoan({ userCollateral, userBorrowed, debt, 
     
     // NEW: Get all metrics in one call
     const metrics = await lendMarket.leverageZapV2.createLoanExpectedMetrics({
-        userCollateral, 
-        userBorrowed, 
+        userCollateral,
         debt, 
         range, 
         quote, 
@@ -1129,9 +1128,9 @@ await lendMarket.leverageZapV2.createLoan({ userCollateral, userBorrowed, debt, 
     //     health: '195.8994783042570637'  // %
     // 
     
-    await lendMarket.leverageZapV2.createLoanIsApproved({ userCollateral, userBorrowed });
+    await lendMarket.leverageZapV2.createLoanIsApproved({ userCollateral });
     // false
-    await lendMarket.leverageZapV2.createLoanApprove({ userCollateral, userBorrowed });
+    await lendMarket.leverageZapV2.createLoanApprove({ userCollateral });
     // [
     //     '0xd5491d9f1e9d8ac84b03867494e35b25efad151c597d2fa4211d7bf5d540c98e',
     //     '0x93565f37ec5be902a824714a30bddc25cf9cd9ed39b4c0e8de61fab44af5bc8c'
@@ -1143,7 +1142,7 @@ await lendMarket.leverageZapV2.createLoan({ userCollateral, userBorrowed, debt, 
     const minRecv = lendMarket.leverageZapV2.calcMinRecv(quote.outAmount, 0.5); // 0.5% slippage
 
     // Create loan, passing router address and calldata from router
-    await lendMarket.leverageZapV2.createLoan({ userCollateral, userBorrowed, debt, range, minRecv, router, calldata });
+    await lendMarket.leverageZapV2.createLoan({ userCollateral, debt, range, minRecv, router, calldata });
     // 0xeb1b7a92bcb02598f00dc8bbfe8fa3a554e7a2b1ca764e0ee45e2bf583edf731
 
     await lendMarket.wallet.balances();
@@ -1188,7 +1187,7 @@ await lendMarket.leverageZapV2.createLoan({ userCollateral, userBorrowed, debt, 
     debt = 10000;
     
     // Get maximum possible debt for given parameters
-    await lendMarket.leverageZapV2.borrowMoreMaxRecv({ userCollateral, userBorrowed, getExpected });
+    await lendMarket.leverageZapV2.borrowMoreMaxRecv({ userCollateral, getExpected });
     // {
     //     maxDebt: '76182.8497941193262889',
     //     maxTotalCollateral: '26.639775583730298462',
@@ -1200,7 +1199,7 @@ await lendMarket.leverageZapV2.createLoan({ userCollateral, userBorrowed, debt, 
     
     // Get quote for swapping (debt + userBorrowed)
     
-    await lendMarket.leverageZapV2.borrowMoreExpectedCollateral({ userCollateral, userBorrowed, dDebt: debt, quote });
+    await lendMarket.leverageZapV2.borrowMoreExpectedCollateral({ userCollateral, dDebt: debt, quote });
     // {
     //     totalCollateral: '5.783452104143246413',
     //     userCollateral: '2.0',
@@ -1211,8 +1210,7 @@ await lendMarket.leverageZapV2.createLoan({ userCollateral, userBorrowed, debt, 
     
     // NEW: Get all metrics in one call
     const metricsBM = await lendMarket.leverageZapV2.borrowMoreExpectedMetrics({
-        userCollateral, 
-        userBorrowed, 
+        userCollateral,
         debt, 
         quote,
         healthIsFull: true  // true for full health, false for not full
@@ -1224,16 +1222,16 @@ await lendMarket.leverageZapV2.createLoan({ userCollateral, userBorrowed, debt, 
     //     health: '91.6798951784708552'  // %
     // }
     
-    await lendMarket.leverageZapV2.borrowMoreIsApproved({ userCollateral, userBorrowed });
+    await lendMarket.leverageZapV2.borrowMoreIsApproved({ userCollateral });
     // true
-    await lendMarket.leverageZapV2.borrowMoreApprove({ userCollateral, userBorrowed });
+    await lendMarket.leverageZapV2.borrowMoreApprove({ userCollateral });
     // []
 
     // Calculate minRecv with slippage protection (see Security Improvements)
     const minRecvBM = lendMarket.leverageZapV2.calcMinRecv(quote.outAmount, 0.5); // 0.5% slippage
 
     // Execute borrowMore, passing router address and calldata from router
-    await lendMarket.leverageZapV2.borrowMore({ userCollateral, userBorrowed, debt, minRecv: minRecvBM, router, calldata });
+    await lendMarket.leverageZapV2.borrowMore({ userCollateral, debt, minRecv: minRecvBM, router, calldata });
     // 0x6357dd6ea7250d7adb2344cd9295f8255fd8fbbe85f00120fbcd1ebf139e057c
 
     await lendMarket.wallet.balances();
@@ -1282,7 +1280,7 @@ await lendMarket.leverageZapV2.createLoan({ userCollateral, userBorrowed, debt, 
     
     // Get quote for swapping (stateCollateral + userCollateral)
     
-    await lendMarket.leverageZapV2.repayExpectedBorrowed({ stateCollateral, userCollateral, userBorrowed, quote });
+    await lendMarket.leverageZapV2.repayExpectedBorrowed({ stateCollateral, userCollateral, quote });
     // {
     //     totalBorrowed: '10998.882838599741571472',
     //     borrowedFromStateCollateral: '6332.588559066494374648',
@@ -1291,16 +1289,15 @@ await lendMarket.leverageZapV2.createLoan({ userCollateral, userBorrowed, debt, 
     //     avgPrice: '3166.29427953324743125312'
     // }
 
-    await lendMarket.leverageZapV2.repayIsFull({ stateCollateral, userCollateral, userBorrowed, quote });
+    await lendMarket.leverageZapV2.repayIsFull({ stateCollateral, userCollateral, quote });
     // false
-    await lendMarket.leverageZapV2.repayIsAvailable({ stateCollateral, userCollateral, userBorrowed, quote });
+    await lendMarket.leverageZapV2.repayIsAvailable({ stateCollateral, userCollateral, quote });
     // true
     
     // NEW: Get all metrics in one call
     const metricsRepay = await lendMarket.leverageZapV2.repayExpectedMetrics({
         stateCollateral, 
-        userCollateral, 
-        userBorrowed, 
+        userCollateral,
         healthIsFull: true,  // true for full health, false for not full
         quote,
         address: llamalend.signerAddress
@@ -1312,16 +1309,16 @@ await lendMarket.leverageZapV2.createLoan({ userCollateral, userBorrowed, debt, 
     //     health: '1699.6097751079226865'  // %
     // }
     
-    await lendMarket.leverageZapV2.repayIsApproved({ userCollateral, userBorrowed });
+    await lendMarket.leverageZapV2.repayIsApproved({ userCollateral });
     // false
-    await lendMarket.leverageZapV2.repayApprove({ userCollateral, userBorrowed });
+    await lendMarket.leverageZapV2.repayApprove({ userCollateral });
     // ['0xd8a8d3b3f67395e1a4f4d4f95b041edcaf1c9f7bab5eb8a8a767467678295498']
 
     // Calculate minRecv with slippage protection (see Security Improvements)
     const minRecvRepay = lendMarket.leverageZapV2.calcMinRecv(quote.outAmount, 0.5); // 0.5% slippage
 
     // Execute repay, passing router address and calldata from router
-    await lendMarket.leverageZapV2.repay({ stateCollateral, userCollateral, userBorrowed, minRecv: minRecvRepay, router, calldata });
+    await lendMarket.leverageZapV2.repay({ stateCollateral, userCollateral, minRecv: minRecvRepay, router, calldata });
     // 0xe48a97fef1c54180a2c7d104d210a95ac1a516fdd22109682179f1582da23a82
 
     await lendMarket.wallet.balances();
@@ -1361,7 +1358,7 @@ await lendMarket.leverageZapV2.createLoan({ userCollateral, userBorrowed, debt, 
     const debt = 2000;
     
     // Get maximum values for all possible ranges
-    await lendMarket.leverageZapV2.createLoanMaxRecvAllRanges({ userCollateral, userBorrowed, getExpected });
+    await lendMarket.leverageZapV2.createLoanMaxRecvAllRanges({ userCollateral, getExpected });
     // {
     //     '4': {
     //         maxDebt: '37916.338071504823875251',
@@ -1414,7 +1411,7 @@ await lendMarket.leverageZapV2.createLoan({ userCollateral, userBorrowed, debt, 
     
     // Get quote for specific debt + userBorrowed
     // and provide getExpected callback
-    await lendMarket.leverageZapV2.createLoanBandsAllRanges({ userCollateral, userBorrowed, debt, getExpected, quote });
+    await lendMarket.leverageZapV2.createLoanBandsAllRanges({ userCollateral, debt, getExpected, quote });
     // {
     //     '4': [ 73, 70 ],
     //     '5': [ 73, 69 ],
@@ -1426,7 +1423,7 @@ await lendMarket.leverageZapV2.createLoan({ userCollateral, userBorrowed, debt, 
     //     '50': [ 97, 48 ]
     // }
 
-    await lendMarket.leverageZapV2.createLoanPricesAllRanges({ userCollateral, userBorrowed, debt, getExpected, quote });
+    await lendMarket.leverageZapV2.createLoanPricesAllRanges({ userCollateral, debt, getExpected, quote });
     // {
     //     '4': [ '1073.323292757532604807', '1136.910693647788699808' ],
     //     '5': [ '1073.323292757532604807', '1153.387660222394333133' ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curvefi/llamalend-api",
-  "version": "2.2.6",
+  "version": "2.3.0",
   "description": "JavaScript library for Curve Lending",
   "main": "lib/index.js",
   "author": "Macket",

--- a/src/constants/aliases.ts
+++ b/src/constants/aliases.ts
@@ -8,7 +8,7 @@ export const ALIASES_ETHEREUM = lowerCaseValues({
     "minter": '0xd061D61a4d941c39E5453435B6345Dc261C2fcE0',
     "gauge_factory": "0xabC000d88f23Bb45525E447528DBF656A9D55bf5",
     "leverage_zap_deprecated": "0xC8E8430dc7Cb23C32543329acCC68c9055C23e18", // odos v3
-    "leverage_zap_v2": "0x0000000000000000000000000000000000000000",
+    "leverage_zap_v2": "0x19010d0f5D5a88aC609B568c91057679eed643d3",
     "leverage_zap_v2_llv2": "0x0000000000000000000000000000000000000000",
     "leverage_markets_start_id": "9",
     "crvUSD": "0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E",
@@ -21,7 +21,7 @@ export const ALIASES_ARBITRUM = lowerCaseValues({
     "gauge_controller": "0x2F50D538606Fa9EDD2B11E2446BEb18C9D5846bB",
     "gauge_factory": "0xabC000d88f23Bb45525E447528DBF656A9D55bf5",
     "leverage_zap_deprecated": "0xFE02553d3Ba4c3f39F36a4632F91404DF94b9AE2", // odos v3
-    "leverage_zap_v2": "0x0000000000000000000000000000000000000000",
+    "leverage_zap_v2": "0x227d2f40E3a66C0344D8Af373b4d48A8744d6560",
     "leverage_zap_v2_llv2": "0x0000000000000000000000000000000000000000",
     "leverage_markets_start_id": "9",
 });
@@ -35,7 +35,7 @@ export const ALIASES_OPTIMISM = lowerCaseValues({
     "gauge_factory": "0x871fBD4E01012e2E8457346059e8C189d664DbA4",
     "old_gauge_end_index": "4",
     "leverage_zap_deprecated": "0xBFab8ebc836E1c4D81837798FC076D219C9a1855", // odos v3
-    "leverage_zap_v2": "0x0000000000000000000000000000000000000000",
+    "leverage_zap_v2": "0x56C526b0159a258887e0d79ec3a80dfb940d0cD7",
     "leverage_zap_v2_llv2": "0x0000000000000000000000000000000000000000",
     "leverage_markets_start_id": "0",
     "gas_oracle": '0xc0d3C0d3C0d3c0D3C0D3C0d3C0d3C0D3C0D3000f',
@@ -50,7 +50,7 @@ export const ALIASES_FRAXTAL = lowerCaseValues({
     "gauge_factory": "0x0b8d6b6cefc7aa1c2852442e518443b1b22e1c52",
     "old_gauge_end_index": "3",
     "leverage_zap_deprecated": "0x3294514B78Df4Bb90132567fcf8E5e99f390B687", // odos v3
-    "leverage_zap_v2": "0x0000000000000000000000000000000000000000",
+    "leverage_zap_v2": "0xA7a4bb50AF91f90b6fEb3388E7f8286aF45b299B",
     "leverage_zap_v2_llv2": "0x0000000000000000000000000000000000000000",
     "leverage_markets_start_id": "0",
 });
@@ -61,7 +61,7 @@ export const ALIASES_SONIC = lowerCaseValues({
     "gauge_controller": "0x2F50D538606Fa9EDD2B11E2446BEb18C9D5846bB",
     "gauge_factory": "0xf3A431008396df8A8b2DF492C913706BDB0874ef",
     "leverage_zap_deprecated": "0x0fE38dCC905eC14F6099a83Ac5C93BF2601300CF", // odos v3
-    "leverage_zap_v2": "0x0000000000000000000000000000000000000000",
+    "leverage_zap_v2": "0xEfadDdE5B43917CcC738AdE6962295A0B343f7CE",
     "leverage_zap_v2_llv2": "0x0000000000000000000000000000000000000000",
     "leverage_markets_start_id": "0",
 });

--- a/src/lendMarkets/interfaces/leverageZapV2.ts
+++ b/src/lendMarkets/interfaces/leverageZapV2.ts
@@ -7,12 +7,10 @@ export interface ILeverageZapV2 {
 
     createLoanMaxRecv: ({
         userCollateral,
-        userBorrowed,
         range,
         getExpected,
     }: {
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         range: number,
         getExpected: GetExpectedFn
     }) => Promise<{
@@ -26,11 +24,9 @@ export interface ILeverageZapV2 {
     }>,
     createLoanMaxRecvAllRanges: ({
         userCollateral,
-        userBorrowed,
         getExpected,
     }: {
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         getExpected: GetExpectedFn
     }) => Promise<IDict<{
         maxDebt: string,
@@ -43,12 +39,10 @@ export interface ILeverageZapV2 {
     }>>,
     createLoanExpectedCollateral: ({
         userCollateral,
-        userBorrowed,
         debt,
         quote,
     }: {
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         debt: TAmount,
         quote: IQuote
     }) => Promise<{
@@ -61,14 +55,12 @@ export interface ILeverageZapV2 {
     }>,
     createLoanExpectedMetrics: ({
         userCollateral,
-        userBorrowed,
         debt,
         range,
         quote,
         healthIsFull,
     }: {
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         debt: TAmount,
         range: number,
         quote: IQuote,
@@ -76,59 +68,48 @@ export interface ILeverageZapV2 {
     }) => Promise<ILeverageMetrics>,
     createLoanMaxRange: ({
         userCollateral,
-        userBorrowed,
         debt,
         getExpected,
     }: {
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         debt: TAmount,
         getExpected: GetExpectedFn
     }) => Promise<number>,
     createLoanBandsAllRanges: ({
         userCollateral,
-        userBorrowed,
         debt,
         getExpected,
         quote,
     }: {
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         debt: TAmount,
         getExpected: GetExpectedFn,
         quote: IQuote
     }) => Promise<IDict<[number, number] | null>>,
     createLoanPricesAllRanges: ({
         userCollateral,
-        userBorrowed,
         debt,
         getExpected,
         quote,
     }: {
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         debt: TAmount,
         getExpected: GetExpectedFn,
         quote: IQuote
     }) => Promise<IDict<[string, string] | null>>,
     createLoanIsApproved: ({
         userCollateral,
-        userBorrowed,
     }: {
-        userCollateral: TAmount,
-        userBorrowed: TAmount
+        userCollateral: TAmount
     }) => Promise<boolean>,
     createLoanApprove: ({
         userCollateral,
-        userBorrowed,
     }: {
-        userCollateral: TAmount,
-        userBorrowed: TAmount
+        userCollateral: TAmount
     }) => Promise<string[]>,
     calcMinRecv: (expected: TAmount, slippage: number) => string,
     createLoan: ({
         userCollateral,
-        userBorrowed,
         debt,
         range,
         minRecv,
@@ -136,7 +117,6 @@ export interface ILeverageZapV2 {
         calldata,
     }: {
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         debt: TAmount,
         range: number,
         minRecv: TAmount,
@@ -144,9 +124,8 @@ export interface ILeverageZapV2 {
         calldata: string
     }) => Promise<string>,
 
-    borrowMoreMaxRecv: ({ userCollateral, userBorrowed, getExpected, address }: {
+    borrowMoreMaxRecv: ({ userCollateral, getExpected, address }: {
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         getExpected: GetExpectedFn,
         address?: string
     }) => Promise<{
@@ -157,9 +136,8 @@ export interface ILeverageZapV2 {
         collateralFromMaxDebt: string,
         avgPrice: string,
     }>,
-    borrowMoreExpectedCollateral: ({ userCollateral, userBorrowed, dDebt, quote, address }: {
+    borrowMoreExpectedCollateral: ({ userCollateral, dDebt, quote, address }: {
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         dDebt: TAmount,
         quote: IQuote,
         address?: string
@@ -170,42 +148,36 @@ export interface ILeverageZapV2 {
         collateralFromDebt: string,
         avgPrice: string
     }>,
-    borrowMoreExpectedMetrics: ({ userCollateral, userBorrowed, debt, quote, healthIsFull, address }: {
+    borrowMoreExpectedMetrics: ({ userCollateral, debt, quote, healthIsFull, address }: {
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         debt: TAmount,
         quote: IQuote,
         healthIsFull?: boolean,
         address?: string
     }) => Promise<ILeverageMetrics>,
-    borrowMoreIsApproved: ({ userCollateral, userBorrowed }: {
-        userCollateral: TAmount,
-        userBorrowed: TAmount
+    borrowMoreIsApproved: ({ userCollateral }: {
+        userCollateral: TAmount
     }) => Promise<boolean>,
-    borrowMoreApprove: ({ userCollateral, userBorrowed }: {
-        userCollateral: TAmount,
-        userBorrowed: TAmount
+    borrowMoreApprove: ({ userCollateral }: {
+        userCollateral: TAmount
     }) => Promise<string[]>,
-    borrowMore: ({ userCollateral, userBorrowed, debt, minRecv, router, calldata }: {
+    borrowMore: ({ userCollateral, debt, minRecv, router, calldata }: {
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         debt: TAmount,
         minRecv: TAmount,
         router: string,
         calldata: string
     }) => Promise<string>,
-    borrowMoreFutureLeverage: ({ userCollateral, userBorrowed, debt, quote, address }: {
+    borrowMoreFutureLeverage: ({ userCollateral, debt, quote, address }: {
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         debt: TAmount,
         quote: IQuote,
         address?: string
     }) => Promise<string>,
 
-    repayExpectedBorrowed: ({ stateCollateral, userCollateral, userBorrowed, quote }: {
+    repayExpectedBorrowed: ({ stateCollateral, userCollateral, quote }: {
         stateCollateral: TAmount,
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         quote: IQuote
     }) => Promise<{
         totalBorrowed: string,
@@ -214,60 +186,50 @@ export interface ILeverageZapV2 {
         userBorrowed: string,
         avgPrice: string
     }>,
-    repayIsFull: ({ stateCollateral, userCollateral, userBorrowed, quote, address }: {
+    repayIsFull: ({ stateCollateral, userCollateral, quote, address }: {
         stateCollateral: TAmount,
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         quote: IQuote,
         address?: string
     }) => Promise<boolean>,
-    repayIsAvailable: ({ stateCollateral, userCollateral, userBorrowed, quote, address }: {
+    repayIsAvailable: ({ stateCollateral, userCollateral, quote, address }: {
         stateCollateral: TAmount,
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         quote: IQuote,
         address?: string
     }) => Promise<boolean>,
-    repayExpectedMetrics: ({ stateCollateral, userCollateral, userBorrowed, healthIsFull, quote, address }: {
+    repayExpectedMetrics: ({ stateCollateral, userCollateral, healthIsFull, quote, address }: {
         stateCollateral: TAmount,
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         healthIsFull: boolean,
         quote: IQuote,
         address: string
     }) => Promise<ILeverageMetrics>,
-    repayIsApproved: ({ userCollateral, userBorrowed }: {
-        userCollateral: TAmount,
-        userBorrowed: TAmount
+    repayIsApproved: ({ userCollateral }: {
+        userCollateral: TAmount
     }) => Promise<boolean>,
-    repayApprove: ({ userCollateral, userBorrowed }: {
-        userCollateral: TAmount,
-        userBorrowed: TAmount
+    repayApprove: ({ userCollateral }: {
+        userCollateral: TAmount
     }) => Promise<string[]>,
-    repay: ({ stateCollateral, userCollateral, userBorrowed, minRecv, router, calldata }: {
+    repay: ({ stateCollateral, userCollateral, minRecv, router, calldata }: {
         stateCollateral: TAmount,
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         minRecv: TAmount,
         router: string,
         calldata: string
     }) => Promise<string>,
-    repayFutureLeverage: ({ stateCollateral, userCollateral, userBorrowed, quote, address }: {
+    repayFutureLeverage: ({ stateCollateral, userCollateral, address }: {
         stateCollateral: TAmount,
         userCollateral: TAmount,
-        userBorrowed: TAmount,
-        quote: IQuote,
         address?: string
     }) => Promise<string>,
 
     estimateGas: {
-        createLoanApprove: ({ userCollateral, userBorrowed }: {
-            userCollateral: TAmount,
-            userBorrowed: TAmount
+        createLoanApprove: ({ userCollateral }: {
+            userCollateral: TAmount
         }) => Promise<TGas>,
-        createLoan: ({ userCollateral, userBorrowed, debt, range, minRecv, router, calldata }: {
+        createLoan: ({ userCollateral, debt, range, minRecv, router, calldata }: {
             userCollateral: TAmount,
-            userBorrowed: TAmount,
             debt: TAmount,
             range: number,
             minRecv: TAmount,
@@ -275,27 +237,23 @@ export interface ILeverageZapV2 {
             calldata: string
         }) => Promise<number>,
 
-        borrowMoreApprove: ({ userCollateral, userBorrowed }: {
-            userCollateral: TAmount,
-            userBorrowed: TAmount
+        borrowMoreApprove: ({ userCollateral }: {
+            userCollateral: TAmount
         }) => Promise<TGas>,
-        borrowMore: ({ userCollateral, userBorrowed, debt, minRecv, router, calldata }: {
+        borrowMore: ({ userCollateral, debt, minRecv, router, calldata }: {
             userCollateral: TAmount,
-            userBorrowed: TAmount,
             debt: TAmount,
             minRecv: TAmount,
             router: string,
             calldata: string
         }) => Promise<number>,
 
-        repayApprove: ({ userCollateral, userBorrowed }: {
-            userCollateral: TAmount,
-            userBorrowed: TAmount
+        repayApprove: ({ userCollateral }: {
+            userCollateral: TAmount
         }) => Promise<TGas>,
-        repay: ({ stateCollateral, userCollateral, userBorrowed, minRecv, router, calldata }: {
+        repay: ({ stateCollateral, userCollateral, minRecv, router, calldata }: {
             stateCollateral: TAmount,
             userCollateral: TAmount,
-            userBorrowed: TAmount,
             minRecv: TAmount,
             router: string,
             calldata: string

--- a/src/lendMarkets/modules/common/leverageZapV2Base.ts
+++ b/src/lendMarkets/modules/common/leverageZapV2Base.ts
@@ -46,7 +46,6 @@ export abstract class LeverageZapV2BaseModule {
 
     protected abstract _createLoanContractCall(
         _userCollateral: bigint,
-        _userBorrowed: bigint,
         _debt: bigint,
         _minRecv: bigint,
         range: number,
@@ -57,7 +56,6 @@ export abstract class LeverageZapV2BaseModule {
 
     protected abstract _borrowMoreContractCall(
         _userCollateral: bigint,
-        _userBorrowed: bigint,
         _debt: bigint,
         _minRecv: bigint,
         router: string,
@@ -67,7 +65,6 @@ export abstract class LeverageZapV2BaseModule {
 
     protected abstract _repayContractCall(
         _userCollateral: bigint,
-        _userBorrowed: bigint,
         _minRecv: bigint,
         router: string,
         exchangeCalldata: string,
@@ -125,9 +122,8 @@ export abstract class LeverageZapV2BaseModule {
         return BN(expected).times(BN(100).minus(slippage)).div(100).toString();
     }
 
-    public async leverageCreateLoanMaxRecv({ userCollateral, userBorrowed, range, getExpected }: {
+    public async leverageCreateLoanMaxRecv({ userCollateral, range, getExpected }: {
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         range: number,
         getExpected: GetExpectedFn
     }): Promise<{
@@ -143,7 +139,6 @@ export abstract class LeverageZapV2BaseModule {
         this._checkLeverageZap();
         if (range > 0) this.market.prices.checkRange(range);
         const _userCollateral = parseUnits(userCollateral, this.market.collateral_token.decimals);
-        const _userBorrowed = parseUnits(userBorrowed, this.market.borrowed_token.decimals);
 
         const oraclePriceBand = await this.market.prices.oraclePriceBand();
         let pAvgBN = BN(await this.market.prices.calcTickPrice(oraclePriceBand)); // upper tick of oracle price band
@@ -155,7 +150,7 @@ export abstract class LeverageZapV2BaseModule {
         const contract = this.llamalend.contracts[this._getLeverageZapAddress()].contract;
         for (let i = 0; i < 5; i++) {
             maxBorrowablePrevBN = maxBorrowableBN;
-            _userEffectiveCollateral = _userCollateral + fromBN(BN(userBorrowed).div(pAvgBN), this.market.collateral_token.decimals);
+            _userEffectiveCollateral = _userCollateral;
             let _maxBorrowable = await contract.max_borrowable(this.market.addresses.controller, _userEffectiveCollateral, _maxLeverageCollateral, range, fromBN(pAvgBN));
             _maxBorrowable = _maxBorrowable * BigInt(970) / BigInt(1000)
             if (_maxBorrowable === BigInt(0)) break;
@@ -166,16 +161,15 @@ export abstract class LeverageZapV2BaseModule {
                 break;
             }
 
-            // additionalCollateral = (userBorrowed / p) + leverageCollateral
             const _maxAdditionalCollateral = BigInt((await getExpected(
                 this.market.addresses.borrowed_token,
                 this.market.addresses.collateral_token,
-                _maxBorrowable + _userBorrowed,
+                _maxBorrowable,
                 this.market.addresses.amm
             )).outAmount);
 
-            pAvgBN = maxBorrowableBN.plus(userBorrowed).div(toBN(_maxAdditionalCollateral, this.market.collateral_token.decimals));
-            _maxLeverageCollateral = _maxAdditionalCollateral - fromBN(BN(userBorrowed).div(pAvgBN), this.market.collateral_token.decimals);
+            pAvgBN = maxBorrowableBN.div(toBN(_maxAdditionalCollateral, this.market.collateral_token.decimals));
+            _maxLeverageCollateral = _maxAdditionalCollateral;
         }
 
         const userEffectiveCollateralBN = maxBorrowableBN.gt(0) ? toBN(_userEffectiveCollateral, this.market.collateral_token.decimals) : BN(0);
@@ -186,16 +180,15 @@ export abstract class LeverageZapV2BaseModule {
             maxDebt: formatNumber(maxBorrowableBN.toString(), this.market.borrowed_token.decimals),
             maxTotalCollateral: formatNumber(maxLeverageCollateralBN.plus(userEffectiveCollateralBN).toString(), this.market.collateral_token.decimals),
             userCollateral: formatNumber(userCollateral, this.market.collateral_token.decimals),
-            collateralFromUserBorrowed: formatNumber(BN(userBorrowed).div(pAvgBN).toString(), this.market.collateral_token.decimals),
+            collateralFromUserBorrowed: formatNumber(BN(0).toString(), this.market.collateral_token.decimals),
             collateralFromMaxDebt: formatNumber(maxLeverageCollateralBN.toString(), this.market.collateral_token.decimals),
             maxLeverage: maxLeverageCollateralBN.plus(userEffectiveCollateralBN).div(userEffectiveCollateralBN).toString(),
             avgPrice: pAvgBN.toString(),
         };
     }
 
-    public leverageCreateLoanMaxRecvAllRanges = memoize(async ({ userCollateral, userBorrowed, getExpected }: {
+    public leverageCreateLoanMaxRecvAllRanges = memoize(async ({ userCollateral, getExpected }: {
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         getExpected: GetExpectedFn
     }): Promise<IDict<{
             maxDebt: string,
@@ -223,7 +216,7 @@ export abstract class LeverageZapV2BaseModule {
         for (let i = 0; i < 5; i++) {
             const pBN = pAvgBN ?? pAvgApproxBN;
             maxBorrowablePrevBN = maxBorrowableBN;
-            const _userEffectiveCollateral: bigint = _userCollateral + fromBN(BN(userBorrowed).div(pBN), this.market.collateral_token.decimals);
+            const _userEffectiveCollateral: bigint = _userCollateral;
             const calls = [];
             for (let N = this.market.minBands; N <= this.market.maxBands; N++) {
                 const j = N - this.market.minBands;
@@ -253,7 +246,7 @@ export abstract class LeverageZapV2BaseModule {
             _maxLeverageCollateral = maxLeverageCollateralBN.map((mlc) => fromBN(mlc, this.market.collateral_token.decimals));
         }
 
-        const userEffectiveCollateralBN = BN(userCollateral).plus(BN(userBorrowed).div(pAvgBN as BigNumber));
+        const userEffectiveCollateralBN = BN(userCollateral);
 
         const res: IDict<{
             maxDebt: string,
@@ -270,7 +263,7 @@ export abstract class LeverageZapV2BaseModule {
                 maxDebt: formatNumber(maxBorrowableBN[j].toString(), this.market.borrowed_token.decimals),
                 maxTotalCollateral: formatNumber(maxLeverageCollateralBN[j].plus(userEffectiveCollateralBN).toString(), this.market.collateral_token.decimals),
                 userCollateral: formatNumber(userCollateral, this.market.collateral_token.decimals),
-                collateralFromUserBorrowed: formatNumber(BN(userBorrowed).div(pAvgBN as BigNumber).toString(), this.market.collateral_token.decimals),
+                collateralFromUserBorrowed: formatNumber(BN(0).toString(), this.market.collateral_token.decimals),
                 collateralFromMaxDebt: formatNumber(maxLeverageCollateralBN[j].toString(), this.market.collateral_token.decimals),
                 maxLeverage: maxLeverageCollateralBN[j].plus(userEffectiveCollateralBN).div(userEffectiveCollateralBN).toString(),
                 avgPrice: (pAvgBN as BigNumber).toString(),
@@ -284,16 +277,14 @@ export abstract class LeverageZapV2BaseModule {
         maxAge: 60 * 1000, // 1m
     });
 
-    private _leverageExpectedCollateral = async (userCollateral: TAmount, userBorrowed: TAmount, debt: TAmount, quote: IQuote, user?: string):
+    private _leverageExpectedCollateral = async (userCollateral: TAmount, debt: TAmount, quote: IQuote, user?: string):
         Promise<{ _futureStateCollateral: bigint, _totalCollateral: bigint, _userCollateral: bigint,
             _collateralFromUserBorrowed: bigint, _collateralFromDebt: bigint, avgPrice: string }> => {
         const _userCollateral = parseUnits(userCollateral, this.market.collateral_token.decimals);
         const _debt = parseUnits(debt, this.market.borrowed_token.decimals);
-        const _userBorrowed = parseUnits(userBorrowed, this.market.borrowed_token.decimals);
-        // additionalCollateral = (userBorrowed / p) + leverageCollateral
         const _additionalCollateral = BigInt(quote.outAmount);
-        const _collateralFromDebt = _debt * BigInt(10**18) / (_debt + _userBorrowed) * _additionalCollateral / BigInt(10**18);
-        const _collateralFromUserBorrowed = _additionalCollateral - _collateralFromDebt;
+        const _collateralFromDebt = _additionalCollateral;
+        const _collateralFromUserBorrowed = BigInt(0);
         let _stateCollateral = BigInt(0);
         if (user) {
             const { _collateral, _borrowed } = await this.market.userPosition.userStateBigInt(user);
@@ -302,21 +293,20 @@ export abstract class LeverageZapV2BaseModule {
         }
         const _totalCollateral = _userCollateral + _additionalCollateral;
         const _futureStateCollateral = _stateCollateral + _totalCollateral;
-        const avgPrice = toBN(_debt + _userBorrowed, this.market.borrowed_token.decimals).div(toBN(_additionalCollateral, this.market.collateral_token.decimals)).toString();
+        const avgPrice = toBN(_debt, this.market.borrowed_token.decimals).div(toBN(_additionalCollateral, this.market.collateral_token.decimals)).toString();
 
         return { _futureStateCollateral, _totalCollateral, _userCollateral, _collateralFromUserBorrowed, _collateralFromDebt, avgPrice };
     };
 
-    public async leverageCreateLoanExpectedCollateral({ userCollateral, userBorrowed, debt, quote }: {
+    public async leverageCreateLoanExpectedCollateral({ userCollateral, debt, quote }: {
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         debt: TAmount,
         quote: IQuote
     }): Promise<{ totalCollateral: string, userCollateral: string, collateralFromUserBorrowed: string, collateralFromDebt: string, leverage: string, avgPrice: string }> {
         this._checkLeverageZap();
 
         const { _totalCollateral, _userCollateral, _collateralFromUserBorrowed, _collateralFromDebt, avgPrice } =
-            await this._leverageExpectedCollateral(userCollateral, userBorrowed, debt, quote);
+            await this._leverageExpectedCollateral(userCollateral, debt, quote);
         return {
             totalCollateral: formatUnits(_totalCollateral, this.market.collateral_token.decimals),
             userCollateral: formatUnits(_userCollateral, this.market.collateral_token.decimals),
@@ -328,9 +318,8 @@ export abstract class LeverageZapV2BaseModule {
         }
     }
 
-    public async leverageCreateLoanExpectedMetrics({ userCollateral, userBorrowed, debt, range, quote, healthIsFull = true }: {
+    public async leverageCreateLoanExpectedMetrics({ userCollateral, debt, range, quote, healthIsFull = true }: {
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         debt: TAmount,
         range: number,
         quote: IQuote,
@@ -338,10 +327,10 @@ export abstract class LeverageZapV2BaseModule {
     }): Promise<ILeverageMetrics> {
         this._checkLeverageZap();
 
-        const [_n2, _n1] = await this._leverageBands(userCollateral, userBorrowed, debt, range, quote);
+        const [_n2, _n1] = await this._leverageBands(userCollateral, debt, range, quote);
 
         const prices = await this.market.prices.getPrices(_n2, _n1);
-        const health = await this._leverageHealth(userCollateral, userBorrowed, debt, range, quote, healthIsFull);
+        const health = await this._leverageHealth(userCollateral, debt, range, quote, healthIsFull);
 
         return {
             priceImpact: quote.priceImpact,
@@ -351,14 +340,13 @@ export abstract class LeverageZapV2BaseModule {
         }
     }
 
-    public async leverageCreateLoanMaxRange({ userCollateral, userBorrowed, debt, getExpected }: {
+    public async leverageCreateLoanMaxRange({ userCollateral, debt, getExpected }: {
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         debt: TAmount,
         getExpected: GetExpectedFn
     }): Promise<number> {
         this._checkLeverageZap();
-        const maxRecv = await this.leverageCreateLoanMaxRecvAllRanges({ userCollateral, userBorrowed, getExpected });
+        const maxRecv = await this.leverageCreateLoanMaxRecvAllRanges({ userCollateral, getExpected });
         for (let N = this.market.minBands; N <= this.market.maxBands; N++) {
             if (BN(debt).gt(maxRecv[N].maxDebt)) return N - 1;
         }
@@ -366,7 +354,7 @@ export abstract class LeverageZapV2BaseModule {
         return this.market.maxBands;
     }
 
-    private _leverageCalcN1 = memoize(async (userCollateral: TAmount, userBorrowed: TAmount, debt: TAmount, range: number, quote: IQuote, user?: string): Promise<bigint> => {
+    private _leverageCalcN1 = memoize(async (userCollateral: TAmount, debt: TAmount, range: number, quote: IQuote, user?: string): Promise<bigint> => {
         if (range > 0) this.market.prices.checkRange(range);
         let _stateDebt = BigInt(0);
         if (user) {
@@ -375,7 +363,7 @@ export abstract class LeverageZapV2BaseModule {
             _stateDebt = _debt;
             if (range < 0) range = Number(this.llamalend.formatUnits(_N, 0));
         }
-        const { _futureStateCollateral } = await this._leverageExpectedCollateral(userCollateral, userBorrowed, debt, quote, user);
+        const { _futureStateCollateral } = await this._leverageExpectedCollateral(userCollateral, debt, quote, user);
         const _debt = _stateDebt + parseUnits(debt, this.market.borrowed_token.decimals);
         return await this._calcDebtN1Call(_futureStateCollateral, _debt, range);
     },
@@ -384,8 +372,8 @@ export abstract class LeverageZapV2BaseModule {
         maxAge: 60 * 1000, // 1m
     });
 
-    private _leverageCalcN1AllRanges = memoize(async (userCollateral: TAmount, userBorrowed: TAmount, debt: TAmount, maxN: number, quote: IQuote): Promise<bigint[]> => {
-        const { _futureStateCollateral } = await this._leverageExpectedCollateral(userCollateral, userBorrowed, debt, quote);
+    private _leverageCalcN1AllRanges = memoize(async (userCollateral: TAmount, debt: TAmount, maxN: number, quote: IQuote): Promise<bigint[]> => {
+        const { _futureStateCollateral } = await this._leverageExpectedCollateral(userCollateral, debt, quote);
         const _debt = parseUnits(debt, this.market.borrowed_token.decimals);
         const calls = [];
         for (let N = this.market.minBands; N <= maxN; N++) {
@@ -398,8 +386,8 @@ export abstract class LeverageZapV2BaseModule {
         maxAge: 60 * 1000, // 1m
     });
 
-    private async _leverageBands(userCollateral: TAmount, userBorrowed: TAmount, debt: TAmount, range: number, quote: IQuote, user?: string): Promise<[bigint, bigint]> {
-        const _n1 = await this._leverageCalcN1(userCollateral, userBorrowed, debt, range, quote, user);
+    private async _leverageBands(userCollateral: TAmount, debt: TAmount, range: number, quote: IQuote, user?: string): Promise<[bigint, bigint]> {
+        const _n1 = await this._leverageCalcN1(userCollateral, debt, range, quote, user);
         if (range < 0) {
             const { N } = await this.market.userPosition.userState(user);
             range = Number(N);
@@ -409,9 +397,9 @@ export abstract class LeverageZapV2BaseModule {
         return [_n2, _n1];
     }
 
-    private async _leverageCreateLoanBandsAllRanges(userCollateral: TAmount, userBorrowed: TAmount, debt: TAmount, getExpected: GetExpectedFn, quote: IQuote): Promise<IDict<[bigint, bigint]>> {
-        const maxN = await this.leverageCreateLoanMaxRange({ userCollateral, userBorrowed, debt, getExpected });
-        const _n1_arr = await this._leverageCalcN1AllRanges(userCollateral, userBorrowed, debt, maxN, quote);
+    private async _leverageCreateLoanBandsAllRanges(userCollateral: TAmount, debt: TAmount, getExpected: GetExpectedFn, quote: IQuote): Promise<IDict<[bigint, bigint]>> {
+        const maxN = await this.leverageCreateLoanMaxRange({ userCollateral, debt, getExpected });
+        const _n1_arr = await this._leverageCalcN1AllRanges(userCollateral, debt, maxN, quote);
         const _n2_arr: bigint[] = [];
         for (let N = this.market.minBands; N <= maxN; N++) {
             _n2_arr.push(_n1_arr[N - this.market.minBands] + BigInt(N - 1));
@@ -425,15 +413,14 @@ export abstract class LeverageZapV2BaseModule {
         return _bands;
     }
 
-    public async leverageCreateLoanBandsAllRanges({ userCollateral, userBorrowed, debt, getExpected, quote }: {
+    public async leverageCreateLoanBandsAllRanges({ userCollateral, debt, getExpected, quote }: {
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         debt: TAmount,
         getExpected: GetExpectedFn,
         quote: IQuote
     }): Promise<IDict<[number, number] | null>> {
         this._checkLeverageZap();
-        const _bands = await this._leverageCreateLoanBandsAllRanges(userCollateral, userBorrowed, debt, getExpected, quote);
+        const _bands = await this._leverageCreateLoanBandsAllRanges(userCollateral, debt, getExpected, quote);
 
         const bands: { [index: number]: [number, number] | null } = {};
         for (let N = this.market.minBands; N <= this.market.maxBands; N++) {
@@ -447,15 +434,14 @@ export abstract class LeverageZapV2BaseModule {
         return bands;
     }
 
-    public async leverageCreateLoanPricesAllRanges({ userCollateral, userBorrowed, debt, getExpected, quote }: {
+    public async leverageCreateLoanPricesAllRanges({ userCollateral, debt, getExpected, quote }: {
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         debt: TAmount,
         getExpected: GetExpectedFn,
         quote: IQuote
     }): Promise<IDict<[string, string] | null>> {
         this._checkLeverageZap();
-        const _bands = await this._leverageCreateLoanBandsAllRanges(userCollateral, userBorrowed, debt, getExpected, quote);
+        const _bands = await this._leverageCreateLoanBandsAllRanges(userCollateral, debt, getExpected, quote);
 
         const prices: { [index: number]: [string, string] | null } = {};
         for (let N = this.market.minBands; N <= this.market.maxBands; N++) {
@@ -471,7 +457,6 @@ export abstract class LeverageZapV2BaseModule {
 
     private async _leverageHealth(
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         dDebt: TAmount,
         range: number,
         quote: IQuote,
@@ -479,7 +464,7 @@ export abstract class LeverageZapV2BaseModule {
         user = this.llamalend.constants.ZERO_ADDRESS
     ): Promise<string> {
         if (range > 0) this.market.prices.checkRange(range);
-        const { _totalCollateral } = await this._leverageExpectedCollateral(userCollateral, userBorrowed, dDebt, quote, user);
+        const { _totalCollateral } = await this._leverageExpectedCollateral(userCollateral, dDebt, quote, user);
         const { _borrowed, _N } = await this.market.userPosition.userStateBigInt(user);
         if (_borrowed > BigInt(0)) throw Error(`User ${user} is already in liquidation mode`);
         if (range < 0) range = Number(this.llamalend.formatUnits(_N, 0));
@@ -494,52 +479,32 @@ export abstract class LeverageZapV2BaseModule {
         return formatUnits(_health);
     }
 
-    public async leverageCreateLoanIsApproved({ userCollateral, userBorrowed }: {
-        userCollateral: TAmount,
-        userBorrowed: TAmount
+    public async leverageCreateLoanIsApproved({ userCollateral }: {
+        userCollateral: TAmount
     }): Promise<boolean> {
         this._checkLeverageZap();
-        const collateralAllowance = await hasAllowance.call(this.llamalend,
+        return await hasAllowance.call(this.llamalend,
             [this.market.collateral_token.address], [userCollateral], this.llamalend.signerAddress, this.market.addresses.controller);
-        const borrowedAllowance = await hasAllowance.call(this.llamalend,
-            [this.market.borrowed_token.address], [userBorrowed], this.llamalend.signerAddress, this._getLeverageZapAddress());
-
-        return collateralAllowance && borrowedAllowance
     }
 
-    public async leverageCreateLoanApproveEstimateGas ({ userCollateral, userBorrowed }: {
-        userCollateral: TAmount,
-        userBorrowed: TAmount
+    public async leverageCreateLoanApproveEstimateGas ({ userCollateral }: {
+        userCollateral: TAmount
     }): Promise<TGas> {
         this._checkLeverageZap();
-        const collateralGas = await ensureAllowanceEstimateGas.call(this.llamalend,
+        return await ensureAllowanceEstimateGas.call(this.llamalend,
             [this.market.collateral_token.address], [userCollateral], this.market.addresses.controller);
-        const borrowedGas = await ensureAllowanceEstimateGas.call(this.llamalend,
-            [this.market.borrowed_token.address], [userBorrowed], this._getLeverageZapAddress());
-
-        if(Array.isArray(collateralGas) && Array.isArray(borrowedGas)) {
-            return [collateralGas[0] + borrowedGas[0], collateralGas[1] + borrowedGas[1]]
-        } else {
-            return (collateralGas as number) + (borrowedGas as number)
-        }
     }
 
-    public async leverageCreateLoanApprove({ userCollateral, userBorrowed }: {
-        userCollateral: TAmount,
-        userBorrowed: TAmount
+    public async leverageCreateLoanApprove({ userCollateral }: {
+        userCollateral: TAmount
     }): Promise<string[]> {
         this._checkLeverageZap();
-        const collateralApproveTx = await ensureAllowance.call(this.llamalend,
+        return await ensureAllowance.call(this.llamalend,
             [this.market.collateral_token.address], [userCollateral], this.market.addresses.controller);
-        const borrowedApproveTx = await ensureAllowance.call(this.llamalend,
-            [this.market.borrowed_token.address], [userBorrowed], this._getLeverageZapAddress());
-
-        return [...collateralApproveTx, ...borrowedApproveTx]
     }
 
     private async _leverageCreateLoan(
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         debt: TAmount,
         range: number,
         minRecv: TAmount,
@@ -551,18 +516,16 @@ export abstract class LeverageZapV2BaseModule {
         this.market.prices.checkRange(range);
 
         const _userCollateral = parseUnits(userCollateral, this.market.collateral_token.decimals);
-        const _userBorrowed = parseUnits(userBorrowed, this.market.borrowed_token.decimals);
         const _debt = parseUnits(debt, this.market.borrowed_token.decimals);
         const _minRecv = parseUnits(minRecv, this.market.collateral_token.decimals);
 
         return await this._createLoanContractCall(
-            _userCollateral, _userBorrowed, _debt, _minRecv, range, router, calldata, estimateGas
+            _userCollateral, _debt, _minRecv, range, router, calldata, estimateGas
         );
     }
 
-    public async leverageCreateLoanEstimateGas({ userCollateral, userBorrowed, debt, range, minRecv, router, calldata }: {
+    public async leverageCreateLoanEstimateGas({ userCollateral, debt, range, minRecv, router, calldata }: {
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         debt: TAmount,
         range: number,
         minRecv: TAmount,
@@ -570,13 +533,12 @@ export abstract class LeverageZapV2BaseModule {
         calldata: string
     }): Promise<number> {
         this._checkLeverageZap();
-        if (!(await this.leverageCreateLoanIsApproved({ userCollateral, userBorrowed }))) throw Error("Approval is needed for gas estimation");
-        return await this._leverageCreateLoan(userCollateral, userBorrowed, debt, range, minRecv, router, calldata,  true) as number;
+        if (!(await this.leverageCreateLoanIsApproved({ userCollateral }))) throw Error("Approval is needed for gas estimation");
+        return await this._leverageCreateLoan(userCollateral, debt, range, minRecv, router, calldata,  true) as number;
     }
 
-    public async leverageCreateLoan({ userCollateral, userBorrowed, debt, range, minRecv, router, calldata }: {
+    public async leverageCreateLoan({ userCollateral, debt, range, minRecv, router, calldata }: {
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         debt: TAmount,
         range: number,
         minRecv: TAmount,
@@ -584,15 +546,14 @@ export abstract class LeverageZapV2BaseModule {
         calldata: string
     }): Promise<string> {
         this._checkLeverageZap();
-        await this.leverageCreateLoanApprove({ userCollateral, userBorrowed });
-        return await this._leverageCreateLoan(userCollateral, userBorrowed, debt, range, minRecv, router, calldata, false) as string;
+        await this.leverageCreateLoanApprove({ userCollateral });
+        return await this._leverageCreateLoan(userCollateral, debt, range, minRecv, router, calldata, false) as string;
     }
 
     // ---------------- LEVERAGE BORROW MORE ----------------
 
-    public async leverageBorrowMoreMaxRecv({ userCollateral, userBorrowed, getExpected, address = "" }: {
+    public async leverageBorrowMoreMaxRecv({ userCollateral, getExpected, address = "" }: {
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         getExpected: GetExpectedFn,
         address?: string
     }): Promise<{
@@ -610,8 +571,8 @@ export abstract class LeverageZapV2BaseModule {
         if (_stateBorrowed > BigInt(0)) throw Error(`User ${address} is already in liquidation mode`);
         const _userCollateral = parseUnits(userCollateral, this.market.collateral_token.decimals);
         const _borrowedFromStateCollateral = await this._getMaxAdditionalBorrowable(_stateCollateral, BigInt(0), _N, _stateDebt, address);
-        const _userBorrowed = _borrowedFromStateCollateral + parseUnits(userBorrowed, this.market.borrowed_token.decimals);
-        userBorrowed = formatUnits(_userBorrowed, this.market.borrowed_token.decimals);
+        const _userBorrowed = _borrowedFromStateCollateral;
+        const userBorrowed = formatUnits(_userBorrowed, this.market.borrowed_token.decimals);
 
         const oraclePriceBand = await this.market.prices.oraclePriceBand();
         let pAvgBN = BN(await this.market.prices.calcTickPrice(oraclePriceBand)); // upper tick of oracle price band
@@ -656,9 +617,8 @@ export abstract class LeverageZapV2BaseModule {
         };
     }
 
-    public async leverageBorrowMoreExpectedCollateral({ userCollateral, userBorrowed, dDebt, quote, address = "" }: {
+    public async leverageBorrowMoreExpectedCollateral({ userCollateral, dDebt, quote, address = "" }: {
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         dDebt: TAmount,
         quote: IQuote,
         address?: string
@@ -667,7 +627,7 @@ export abstract class LeverageZapV2BaseModule {
         address = _getAddress.call(this.llamalend, address);
 
         const { _totalCollateral, _userCollateral, _collateralFromUserBorrowed, _collateralFromDebt, avgPrice } =
-            await this._leverageExpectedCollateral(userCollateral, userBorrowed, dDebt, quote, address);
+            await this._leverageExpectedCollateral(userCollateral, dDebt, quote, address);
         return {
             totalCollateral: formatUnits(_totalCollateral, this.market.collateral_token.decimals),
             userCollateral: formatUnits(_userCollateral, this.market.collateral_token.decimals),
@@ -677,9 +637,8 @@ export abstract class LeverageZapV2BaseModule {
         }
     }
 
-    public async leverageBorrowMoreExpectedMetrics({ userCollateral, userBorrowed, debt, quote, healthIsFull = true, address = "" }: {
+    public async leverageBorrowMoreExpectedMetrics({ userCollateral, debt, quote, healthIsFull = true, address = "" }: {
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         debt: TAmount,
         quote: IQuote,
         healthIsFull?: boolean,
@@ -689,10 +648,10 @@ export abstract class LeverageZapV2BaseModule {
         address = _getAddress.call(this.llamalend, address);
 
 
-        const [_n2, _n1] = await this._leverageBands(userCollateral, userBorrowed, debt, -1, quote, address);
+        const [_n2, _n1] = await this._leverageBands(userCollateral, debt, -1, quote, address);
 
         const prices = await this.market.prices.getPrices(_n2, _n1);
-        const health = await this._leverageHealth(userCollateral, userBorrowed, debt, -1, quote, healthIsFull, address);
+        const health = await this._leverageHealth(userCollateral, debt, -1, quote, healthIsFull, address);
 
         return {
             priceImpact: quote.priceImpact,
@@ -704,7 +663,6 @@ export abstract class LeverageZapV2BaseModule {
 
     private async _leverageBorrowMore(
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         debt: TAmount,
         minRecv: TAmount,
         router: string,
@@ -713,58 +671,52 @@ export abstract class LeverageZapV2BaseModule {
     ): Promise<string | TGas>  {
         if (!(await this.market.userPosition.userLoanExists())) throw Error("Loan does not exist");
         const _userCollateral = parseUnits(userCollateral, this.market.collateral_token.decimals);
-        const _userBorrowed = parseUnits(userBorrowed, this.market.borrowed_token.decimals);
         const _debt = parseUnits(debt, this.market.borrowed_token.decimals);
         const _minRecv = parseUnits(minRecv, this.market.collateral_token.decimals);
 
         return await this._borrowMoreContractCall(
-            _userCollateral, _userBorrowed, _debt, _minRecv, router, calldata, estimateGas
+            _userCollateral, _debt, _minRecv, router, calldata, estimateGas
         );
     }
 
-    public async leverageBorrowMoreIsApproved({ userCollateral, userBorrowed }: {
-        userCollateral: TAmount,
-        userBorrowed: TAmount
+    public async leverageBorrowMoreIsApproved({ userCollateral }: {
+        userCollateral: TAmount
     }): Promise<boolean> {
-        return await this.leverageCreateLoanIsApproved({ userCollateral, userBorrowed });
+        return await this.leverageCreateLoanIsApproved({ userCollateral });
     }
 
-    public async leverageBorrowMoreApprove({ userCollateral, userBorrowed }: {
-        userCollateral: TAmount,
-        userBorrowed: TAmount
+    public async leverageBorrowMoreApprove({ userCollateral }: {
+        userCollateral: TAmount
     }): Promise<string[]> {
-        return await this.leverageCreateLoanApprove({ userCollateral, userBorrowed });
+        return await this.leverageCreateLoanApprove({ userCollateral });
     }
 
-    public async leverageBorrowMoreEstimateGas({ userCollateral, userBorrowed, debt, minRecv, router, calldata }: {
+    public async leverageBorrowMoreEstimateGas({ userCollateral, debt, minRecv, router, calldata }: {
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         debt: TAmount,
         minRecv: TAmount,
         router: string,
         calldata: string
     }): Promise<number> {
         this._checkLeverageZap();
-        if (!(await this.leverageCreateLoanIsApproved({ userCollateral, userBorrowed }))) throw Error("Approval is needed for gas estimation");
-        return await this._leverageBorrowMore(userCollateral, userBorrowed, debt, minRecv, router, calldata,  true) as number;
+        if (!(await this.leverageCreateLoanIsApproved({ userCollateral }))) throw Error("Approval is needed for gas estimation");
+        return await this._leverageBorrowMore(userCollateral, debt, minRecv, router, calldata,  true) as number;
     }
 
-    public async leverageBorrowMore({ userCollateral, userBorrowed, debt, minRecv, router, calldata }: {
+    public async leverageBorrowMore({ userCollateral, debt, minRecv, router, calldata }: {
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         debt: TAmount,
         minRecv: TAmount,
         router: string,
         calldata: string
     }): Promise<string> {
         this._checkLeverageZap();
-        await this.leverageCreateLoanApprove({ userCollateral, userBorrowed });
-        return await this._leverageBorrowMore(userCollateral, userBorrowed, debt, minRecv, router, calldata, false) as string;
+        await this.leverageCreateLoanApprove({ userCollateral });
+        return await this._leverageBorrowMore(userCollateral, debt, minRecv, router, calldata, false) as string;
     }
 
-    public async leverageBorrowMoreFutureLeverage({ userCollateral, userBorrowed, debt, quote, address = "" }: {
+    public async leverageBorrowMoreFutureLeverage({ userCollateral, debt, quote, address = "" }: {
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         debt: TAmount,
         quote: IQuote,
         address?: string
@@ -776,7 +728,6 @@ export abstract class LeverageZapV2BaseModule {
 
         const expected = await this.leverageBorrowMoreExpectedCollateral({
             userCollateral,
-            userBorrowed,
             dDebt: debt,
             quote,
             address,
@@ -790,7 +741,7 @@ export abstract class LeverageZapV2BaseModule {
 
     // ---------------- LEVERAGE REPAY ----------------
 
-    private _leverageRepayExpectedBorrowed = (stateCollateral: TAmount, userCollateral: TAmount, userBorrowed: TAmount, quote: IQuote):
+    private _leverageRepayExpectedBorrowed = (stateCollateral: TAmount, userCollateral: TAmount, quote: IQuote):
         { _totalBorrowed: bigint, _borrowedFromStateCollateral: bigint, _borrowedFromUserCollateral: bigint, avgPrice: string } => {
         this._checkLeverageZap();
         const _stateCollateral = parseUnits(stateCollateral, this.market.collateral_token.decimals);
@@ -803,51 +754,48 @@ export abstract class LeverageZapV2BaseModule {
             _borrowedFromStateCollateral = _stateCollateral * BigInt(10 ** 18) / (_stateCollateral + _userCollateral) * _borrowedExpected / BigInt(10 ** 18);
             _borrowedFromUserCollateral = _borrowedExpected - _borrowedFromStateCollateral;
         }
-        const _totalBorrowed = _borrowedExpected + parseUnits(userBorrowed, this.market.borrowed_token.decimals);
+        const _totalBorrowed = _borrowedExpected;
         const avgPrice = toBN(_borrowedExpected, this.market.borrowed_token.decimals).div(toBN(_stateCollateral + _userCollateral, this.market.collateral_token.decimals)).toString();
 
         return { _totalBorrowed, _borrowedFromStateCollateral, _borrowedFromUserCollateral, avgPrice }
     };
 
-    public leverageRepayExpectedBorrowed = async ({ stateCollateral, userCollateral, userBorrowed, quote }: {
+    public leverageRepayExpectedBorrowed = async ({ stateCollateral, userCollateral, quote }: {
         stateCollateral: TAmount,
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         quote: IQuote
     }): Promise<{ totalBorrowed: string, borrowedFromStateCollateral: string, borrowedFromUserCollateral: string, userBorrowed: string, avgPrice: string }> => {
         this._checkLeverageZap();
 
         const { _totalBorrowed, _borrowedFromStateCollateral, _borrowedFromUserCollateral, avgPrice } =
-            this._leverageRepayExpectedBorrowed(stateCollateral, userCollateral, userBorrowed, quote);
+            this._leverageRepayExpectedBorrowed(stateCollateral, userCollateral, quote);
 
         return {
             totalBorrowed: formatUnits(_totalBorrowed, this.market.borrowed_token.decimals),
             borrowedFromStateCollateral: formatUnits(_borrowedFromStateCollateral, this.market.borrowed_token.decimals),
             borrowedFromUserCollateral: formatUnits(_borrowedFromUserCollateral, this.market.borrowed_token.decimals),
-            userBorrowed: formatNumber(userBorrowed, this.market.borrowed_token.decimals),
+            userBorrowed: formatNumber(0, this.market.borrowed_token.decimals),
             avgPrice,
         }
     };
 
-    public async leverageRepayIsFull({ stateCollateral, userCollateral, userBorrowed, quote, address = "" }: {
+    public async leverageRepayIsFull({ stateCollateral, userCollateral, quote, address = "" }: {
         stateCollateral: TAmount,
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         quote: IQuote,
         address?: string
     }): Promise<boolean> {
         this._checkLeverageZap();
         address = _getAddress.call(this.llamalend, address);
         const { _borrowed: _stateBorrowed, _debt } = await this.market.userPosition.userStateBigInt(address);
-        const { _totalBorrowed } = this._leverageRepayExpectedBorrowed(stateCollateral, userCollateral, userBorrowed, quote);
+        const { _totalBorrowed } = this._leverageRepayExpectedBorrowed(stateCollateral, userCollateral, quote);
 
         return _stateBorrowed + _totalBorrowed > _debt;
     }
 
-    public async leverageRepayIsAvailable({ stateCollateral, userCollateral, userBorrowed, quote, address = "" }: {
+    public async leverageRepayIsAvailable({ stateCollateral, userCollateral, quote, address = "" }: {
         stateCollateral: TAmount,
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         quote: IQuote,
         address?: string
     }): Promise<boolean> {
@@ -863,15 +811,14 @@ export abstract class LeverageZapV2BaseModule {
         // Can't spend more than user has
         if (BN(stateCollateral).gt(collateral)) return false;
         // Only full repayment and closing the position is available if user is underwater+
-        if (BN(borrowed).gt(0)) return await this.leverageRepayIsFull({ stateCollateral, userCollateral, userBorrowed, quote, address });
+        if (BN(borrowed).gt(0)) return await this.leverageRepayIsFull({ stateCollateral, userCollateral, quote, address });
 
         return true;
     }
 
-    public async leverageRepayExpectedMetrics({ stateCollateral, userCollateral, userBorrowed, healthIsFull, quote, address }: {
+    public async leverageRepayExpectedMetrics({ stateCollateral, userCollateral, healthIsFull, quote, address }: {
         stateCollateral: TAmount,
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         healthIsFull: boolean,
         quote: IQuote,
         address: string
@@ -879,9 +826,9 @@ export abstract class LeverageZapV2BaseModule {
         this._checkLeverageZap();
         address = _getAddress.call(this.llamalend, address);
 
-        const [_n2, _n1] = await this._leverageRepayBands(stateCollateral, userCollateral, userBorrowed, quote, address);
+        const [_n2, _n1] = await this._leverageRepayBands(stateCollateral, userCollateral, quote, address);
         const prices = await this.market.prices.getPrices(_n2, _n1);
-        const health = await this._leverageRepayHealth(stateCollateral, userCollateral, userBorrowed, quote, healthIsFull, address);
+        const health = await this._leverageRepayHealth(stateCollateral, userCollateral, quote, healthIsFull, address);
 
         const _stateCollateral = parseUnits(stateCollateral, this.market.collateral_token.decimals);
         const _userCollateral = parseUnits(userCollateral, this.market.collateral_token.decimals);
@@ -895,9 +842,9 @@ export abstract class LeverageZapV2BaseModule {
         }
     }
 
-    private _leverageRepayBands = memoize( async (stateCollateral: TAmount, userCollateral: TAmount, userBorrowed: TAmount, quote: IQuote, address: string): Promise<[bigint, bigint]> => {
+    private _leverageRepayBands = memoize( async (stateCollateral: TAmount, userCollateral: TAmount, quote: IQuote, address: string): Promise<[bigint, bigint]> => {
         address = _getAddress.call(this.llamalend, address);
-        if (!(await this.leverageRepayIsAvailable({ stateCollateral, userCollateral, userBorrowed, quote, address }))) return [parseUnits(0, 0), parseUnits(0, 0)];
+        if (!(await this.leverageRepayIsAvailable({ stateCollateral, userCollateral, quote, address }))) return [parseUnits(0, 0), parseUnits(0, 0)];
 
         const _stateRepayCollateral = parseUnits(stateCollateral, this.market.collateral_token.decimals);
         const { _collateral: _stateCollateral, _debt: _stateDebt, _N } = await this.market.userPosition.userStateBigInt(address);
@@ -906,7 +853,7 @@ export abstract class LeverageZapV2BaseModule {
 
         let _n1 = parseUnits(0, 0);
         let _n2 = parseUnits(0, 0);
-        const { _totalBorrowed: _repayExpected } = this._leverageRepayExpectedBorrowed(stateCollateral, userCollateral, userBorrowed, quote);
+        const { _totalBorrowed: _repayExpected } = this._leverageRepayExpectedBorrowed(stateCollateral, userCollateral, quote);
         try {
             _n1 = await this._calcDebtN1Call(_stateCollateral - _stateRepayCollateral, _stateDebt - _repayExpected, _N);
             _n2 = _n1 + (_N - BigInt(1));
@@ -921,14 +868,14 @@ export abstract class LeverageZapV2BaseModule {
     });
 
 
-    private async _leverageRepayHealth(stateCollateral: TAmount, userCollateral: TAmount, userBorrowed: TAmount, quote: IQuote, full = true, address = ""): Promise<string> {
+    private async _leverageRepayHealth(stateCollateral: TAmount, userCollateral: TAmount, quote: IQuote, full = true, address = ""): Promise<string> {
         this._checkLeverageZap();
         address = _getAddress.call(this.llamalend, address);
         const { _borrowed: _stateBorrowed, _debt, _N } = await this.market.userPosition.userStateBigInt(address);
         if (_stateBorrowed > BigInt(0)) return "0.0";
-        if (!(await this.leverageRepayIsAvailable({ stateCollateral, userCollateral, userBorrowed, quote, address }))) return "0.0";
+        if (!(await this.leverageRepayIsAvailable({ stateCollateral, userCollateral, quote, address }))) return "0.0";
 
-        const { _totalBorrowed } = this._leverageRepayExpectedBorrowed(stateCollateral, userCollateral, userBorrowed, quote);
+        const { _totalBorrowed } = this._leverageRepayExpectedBorrowed(stateCollateral, userCollateral, quote);
         const _dCollateral = parseUnits(stateCollateral, this.market.collateral_token.decimals) * BigInt(-1);
         const _dDebt = _totalBorrowed * BigInt(-1);
 
@@ -939,39 +886,36 @@ export abstract class LeverageZapV2BaseModule {
         return this.llamalend.formatUnits(_health);
     }
 
-    public async leverageRepayIsApproved({ userCollateral, userBorrowed }: {
-        userCollateral: TAmount,
-        userBorrowed: TAmount
+    public async leverageRepayIsApproved({ userCollateral }: {
+        userCollateral: TAmount
     }): Promise<boolean> {
         this._checkLeverageZap();
         return await hasAllowance.call(this.llamalend,
-            [this.market.collateral_token.address, this.market.borrowed_token.address],
-            [userCollateral, userBorrowed],
+            [this.market.collateral_token.address],
+            [userCollateral],
             this.llamalend.signerAddress,
             this._getLeverageZapAddress()
         );
     }
 
-    public async leverageRepayApproveEstimateGas ({ userCollateral, userBorrowed }: {
-        userCollateral: TAmount,
-        userBorrowed: TAmount
+    public async leverageRepayApproveEstimateGas ({ userCollateral }: {
+        userCollateral: TAmount
     }): Promise<TGas> {
         this._checkLeverageZap();
         return await ensureAllowanceEstimateGas.call(this.llamalend,
-            [this.market.collateral_token.address, this.market.borrowed_token.address],
-            [userCollateral, userBorrowed],
+            [this.market.collateral_token.address],
+            [userCollateral],
             this._getLeverageZapAddress()
         );
     }
 
-    public async leverageRepayApprove({ userCollateral, userBorrowed }: {
-        userCollateral: TAmount,
-        userBorrowed: TAmount
+    public async leverageRepayApprove({ userCollateral }: {
+        userCollateral: TAmount
     }): Promise<string[]> {
         this._checkLeverageZap();
         return await ensureAllowance.call(this.llamalend,
-            [this.market.collateral_token.address, this.market.borrowed_token.address],
-            [userCollateral, userBorrowed],
+            [this.market.collateral_token.address],
+            [userCollateral],
             this._getLeverageZapAddress()
         );
     }
@@ -979,7 +923,6 @@ export abstract class LeverageZapV2BaseModule {
     private async _leverageRepay(
         stateCollateral: TAmount,
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         minRecv: TAmount,
         router: string,
         calldata: string,
@@ -988,46 +931,42 @@ export abstract class LeverageZapV2BaseModule {
         if (!(await this.market.userPosition.userLoanExists())) throw Error("Loan does not exist");
         const _stateCollateral = parseUnits(stateCollateral, this.market.collateral_token.decimals);
         const _userCollateral = parseUnits(userCollateral, this.market.collateral_token.decimals);
-        const _userBorrowed = parseUnits(userBorrowed, this.market.borrowed_token.decimals);
         const _minRecv = parseUnits(minRecv, this.market.borrowed_token.decimals);
 
         const exchangeCalldata = _stateCollateral + _userCollateral > BigInt(0) ? calldata : "0x";
 
         return await this._repayContractCall(
-            _userCollateral, _userBorrowed, _minRecv, router, exchangeCalldata, estimateGas
+            _userCollateral, _minRecv, router, exchangeCalldata, estimateGas
         );
     }
 
-    public async leverageRepayEstimateGas({ stateCollateral, userCollateral, userBorrowed, minRecv, router, calldata }: {
+    public async leverageRepayEstimateGas({ stateCollateral, userCollateral, minRecv, router, calldata }: {
         stateCollateral: TAmount,
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         minRecv: TAmount,
         router: string,
         calldata: string,
     }): Promise<number> {
         this._checkLeverageZap();
-        if (!(await this.leverageRepayIsApproved({ userCollateral, userBorrowed }))) throw Error("Approval is needed for gas estimation");
-        return await this._leverageRepay(stateCollateral, userCollateral, userBorrowed, minRecv, router, calldata, true) as number;
+        if (!(await this.leverageRepayIsApproved({ userCollateral }))) throw Error("Approval is needed for gas estimation");
+        return await this._leverageRepay(stateCollateral, userCollateral, minRecv, router, calldata, true) as number;
     }
 
-    public async leverageRepay({ stateCollateral, userCollateral, userBorrowed, minRecv, router, calldata }: {
+    public async leverageRepay({ stateCollateral, userCollateral, minRecv, router, calldata }: {
         stateCollateral: TAmount,
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         minRecv: TAmount,
         router: string,
         calldata: string,
     }): Promise<string> {
         this._checkLeverageZap();
-        await this.leverageRepayApprove({ userCollateral, userBorrowed });
-        return await this._leverageRepay(stateCollateral, userCollateral, userBorrowed, minRecv, router, calldata, false) as string;
+        await this.leverageRepayApprove({ userCollateral });
+        return await this._leverageRepay(stateCollateral, userCollateral, minRecv, router, calldata, false) as string;
     }
 
-    public async leverageRepayFutureLeverage({ stateCollateral, userCollateral, userBorrowed, address = "" }: {
+    public async leverageRepayFutureLeverage({ stateCollateral, userCollateral, address = "" }: {
         stateCollateral: TAmount,
         userCollateral: TAmount,
-        userBorrowed: TAmount,
         address?: string
     }): Promise<string> {
         address = _getAddress.call(this.llamalend, address);
@@ -1035,10 +974,8 @@ export abstract class LeverageZapV2BaseModule {
 
         const { stateCollateral: currentStateCollateral, totalDepositFromUser } = await this.market.userPosition.getCurrentLeverageParams(address);
 
-        const collateralFromUserBorrowed = await this.market.amm.swapExpected(0, 1, userBorrowed);
-
         const futureCollateralState = BN(currentStateCollateral).minus(stateCollateral);
-        const futureTotalDepositFromUserPrecise = BN(totalDepositFromUser).plus(userCollateral).plus(collateralFromUserBorrowed);
+        const futureTotalDepositFromUserPrecise = BN(totalDepositFromUser).plus(userCollateral);
 
         return futureCollateralState.div(futureTotalDepositFromUserPrecise).toString();
     }

--- a/src/lendMarkets/modules/v1/leverageV1ZapV2.ts
+++ b/src/lendMarkets/modules/v1/leverageV1ZapV2.ts
@@ -60,7 +60,6 @@ export class LeverageV1ZapV2Module extends LeverageZapV2BaseModule {
 
     protected override async _createLoanContractCall(
         _userCollateral: bigint,
-        _userBorrowed: bigint,
         _debt: bigint,
         _minRecv: bigint,
         range: number,
@@ -68,14 +67,14 @@ export class LeverageV1ZapV2Module extends LeverageZapV2BaseModule {
         exchangeCalldata: string,
         estimateGas: boolean
     ): Promise<string | TGas> {
-        const zapCalldata = buildCalldataForLeverageZapV2(router, exchangeCalldata);
+        const zapCalldata = buildCalldataForLeverageZapV2({controllerId: parseUnits(this._getMarketId(), 0), _minRecv ,router, exchangeCalldata});
         const contract = this.llamalend.contracts[this.market.addresses.controller].contract;
         const gas = await contract.create_loan_extended.estimateGas(
             _userCollateral,
             _debt,
             range,
             this._getLeverageZapAddress(),
-            [0, parseUnits(this._getMarketId(), 0), _userBorrowed, _minRecv],
+            [],
             zapCalldata,
             { ...this.llamalend.constantOptions }
         );
@@ -88,7 +87,7 @@ export class LeverageV1ZapV2Module extends LeverageZapV2BaseModule {
             _debt,
             range,
             this._getLeverageZapAddress(),
-            [0, parseUnits(this._getMarketId(), 0), _userBorrowed, _minRecv],
+            [],
             zapCalldata,
             { ...this.llamalend.options, gasLimit }
         )).hash;
@@ -96,20 +95,19 @@ export class LeverageV1ZapV2Module extends LeverageZapV2BaseModule {
 
     protected override async _borrowMoreContractCall(
         _userCollateral: bigint,
-        _userBorrowed: bigint,
         _debt: bigint,
         _minRecv: bigint,
         router: string,
         exchangeCalldata: string,
         estimateGas: boolean
     ): Promise<string | TGas> {
-        const zapCalldata = buildCalldataForLeverageZapV2(router, exchangeCalldata);
+        const zapCalldata = buildCalldataForLeverageZapV2({controllerId: parseUnits(this._getMarketId(), 0), _minRecv,router, exchangeCalldata});
         const contract = this.llamalend.contracts[this.market.addresses.controller].contract;
         const gas = await contract.borrow_more_extended.estimateGas(
             _userCollateral,
             _debt,
             this._getLeverageZapAddress(),
-            [0, parseUnits(this._getMarketId(), 0), _userBorrowed, _minRecv],
+            [],
             zapCalldata,
             { ...this.llamalend.constantOptions }
         );
@@ -121,7 +119,7 @@ export class LeverageV1ZapV2Module extends LeverageZapV2BaseModule {
             _userCollateral,
             _debt,
             this._getLeverageZapAddress(),
-            [0, parseUnits(this._getMarketId(), 0), _userBorrowed, _minRecv],
+            [],
             zapCalldata,
             { ...this.llamalend.options, gasLimit }
         )).hash;
@@ -129,17 +127,16 @@ export class LeverageV1ZapV2Module extends LeverageZapV2BaseModule {
 
     protected override async _repayContractCall(
         _userCollateral: bigint,
-        _userBorrowed: bigint,
         _minRecv: bigint,
         router: string,
         exchangeCalldata: string,
         estimateGas: boolean
     ): Promise<string | TGas> {
-        const zapCalldata = buildCalldataForLeverageZapV2(router, exchangeCalldata);
+        const zapCalldata = buildCalldataForLeverageZapV2({controllerId: parseUnits(this._getMarketId(), 0), _minRecv ,router, exchangeCalldata});
         const contract = this.llamalend.contracts[this.market.addresses.controller].contract;
         const gas = await contract.repay_extended.estimateGas(
             this._getLeverageZapAddress(),
-            [0, parseUnits(this._getMarketId(), 0), _userCollateral, _userBorrowed, _minRecv],
+            [],
             zapCalldata
         );
         if (estimateGas) return smartNumber(gas);
@@ -148,7 +145,7 @@ export class LeverageV1ZapV2Module extends LeverageZapV2BaseModule {
         const gasLimit = _mulBy1_3(DIGas(gas));
         return (await contract.repay_extended(
             this._getLeverageZapAddress(),
-            [0, parseUnits(this._getMarketId(), 0), _userCollateral, _userBorrowed, _minRecv],
+            [],
             zapCalldata,
             { ...this.llamalend.options, gasLimit }
         )).hash;

--- a/src/lendMarkets/modules/v2/leverageV2ZapV2.ts
+++ b/src/lendMarkets/modules/v2/leverageV2ZapV2.ts
@@ -6,7 +6,7 @@ import {
     _mulBy1_3,
     DIGas,
     MAX_ACTIVE_BAND,
-    buildCalldataForLeverageZapV2Llv2,
+    buildCalldataForLeverageZapV2,
 } from "../../../utils";
 
 export class LeverageV2ZapV2Module extends LeverageZapV2BaseModule {
@@ -66,7 +66,6 @@ export class LeverageV2ZapV2Module extends LeverageZapV2BaseModule {
 
     protected override async _createLoanContractCall(
         _userCollateral: bigint,
-        _userBorrowed: bigint,
         _debt: bigint,
         _minRecv: bigint,
         range: number,
@@ -77,11 +76,9 @@ export class LeverageV2ZapV2Module extends LeverageZapV2BaseModule {
         const contract = this.llamalend.contracts[this.market.addresses.controller].contract;
         const _for = _getAddress.call(this.llamalend, '');
         const _callbacker = this._getLeverageZapAddress();
-        const zapCalldata = buildCalldataForLeverageZapV2Llv2({
-            op: 'create_loan',
+        const zapCalldata = buildCalldataForLeverageZapV2({
             controllerId: this._getMarketId(),
-            userBorrowed: _userBorrowed,
-            minRecv: _minRecv,
+            _minRecv,
             router,
             exchangeCalldata,
         });
@@ -112,7 +109,6 @@ export class LeverageV2ZapV2Module extends LeverageZapV2BaseModule {
 
     protected override async _borrowMoreContractCall(
         _userCollateral: bigint,
-        _userBorrowed: bigint,
         _debt: bigint,
         _minRecv: bigint,
         router: string,
@@ -122,11 +118,9 @@ export class LeverageV2ZapV2Module extends LeverageZapV2BaseModule {
         const contract = this.llamalend.contracts[this.market.addresses.controller].contract;
         const _for = _getAddress.call(this.llamalend, '');
         const _callbacker = this._getLeverageZapAddress();
-        const zapCalldata = buildCalldataForLeverageZapV2Llv2({
-            op: 'borrow_more',
+        const zapCalldata = buildCalldataForLeverageZapV2({
             controllerId: this._getMarketId(),
-            userBorrowed: _userBorrowed,
-            minRecv: _minRecv,
+            _minRecv,
             router,
             exchangeCalldata,
         });
@@ -155,7 +149,6 @@ export class LeverageV2ZapV2Module extends LeverageZapV2BaseModule {
 
     protected override async _repayContractCall(
         _userCollateral: bigint,
-        _userBorrowed: bigint,
         _minRecv: bigint,
         router: string,
         exchangeCalldata: string,
@@ -164,12 +157,9 @@ export class LeverageV2ZapV2Module extends LeverageZapV2BaseModule {
         const contract = this.llamalend.contracts[this.market.addresses.controller].contract;
         const _for = _getAddress.call(this.llamalend, '');
         const _callbacker = this._getLeverageZapAddress();
-        const zapCalldata = buildCalldataForLeverageZapV2Llv2({
-            op: 'repay',
+        const zapCalldata = buildCalldataForLeverageZapV2({
             controllerId: this._getMarketId(),
-            userCollateral: _userCollateral,
-            userBorrowed: _userBorrowed,
-            minRecv: _minRecv,
+            _minRecv,
             router,
             exchangeCalldata,
         });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -484,43 +484,21 @@ export const calculateFutureLeverage = (
     }
 };
 
-export const buildCalldataForLeverageZapV2 = (routerAddress: string, exchangeCalldata: string): string => {
-    const cleanCalldata = exchangeCalldata.startsWith('0x') ? exchangeCalldata.slice(2) : exchangeCalldata;
-
-    const abiCoder = ethers.AbiCoder.defaultAbiCoder();
-    return abiCoder.encode(
-        ['address', 'bytes'],
-        [routerAddress, '0x' + cleanCalldata]
-    );
-};
-
-//   - create_loan / borrow_more: (uint256 controllerId, uint256 userBorrowed, uint256 minRecv, address router, bytes exchangeCalldata)
-//   - repay:                     (uint256 controllerId, uint256 userCollateral, uint256 userBorrowed, uint256 minRecv, address router, bytes exchangeCalldata)
 export type LeverageZapV2LLv2CalldataParams = {
     controllerId: number | string | bigint;
-    minRecv: bigint;
+    _minRecv: bigint;
     router: string;
     exchangeCalldata: string;
-} & (
-    { op: 'create_loan' | 'borrow_more'; userBorrowed: bigint }
-    | {op: 'repay'; userCollateral: bigint; userBorrowed: bigint }
-    );
+}
 
-export const buildCalldataForLeverageZapV2Llv2 = (params: LeverageZapV2LLv2CalldataParams): string => {
+export const buildCalldataForLeverageZapV2 = (params: LeverageZapV2LLv2CalldataParams): string => {
     const cleanCalldata = params.exchangeCalldata.startsWith('0x') ? params.exchangeCalldata.slice(2) : params.exchangeCalldata;
     const exchangeBytes = '0x' + cleanCalldata;
     const abiCoder = ethers.AbiCoder.defaultAbiCoder();
 
-    if (params.op === 'repay') {
-        return abiCoder.encode(
-            ['uint256', 'uint256', 'uint256', 'uint256', 'address', 'bytes'],
-            [BigInt(params.controllerId), params.userCollateral, params.userBorrowed, params.minRecv, params.router, exchangeBytes]
-        );
-    }
-
     return abiCoder.encode(
-        ['uint256', 'uint256', 'uint256', 'address', 'bytes'],
-        [BigInt(params.controllerId), params.userBorrowed, params.minRecv, params.router, exchangeBytes]
+        ['uint256', 'uint256', 'address', 'bytes'],
+        [BigInt(params.controllerId), params._minRecv, params.router, exchangeBytes]
     );
 };
 


### PR DESCRIPTION
One important change due to the new security requirements: ZapV2 no longer supports userBorrowed (i.e. borrowed tokens provided directly from the user's wallet). The same restriction will apply to LLv2 as well.