### PR TITLE
feat: add user discounts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curvefi/llamalend-api",
-  "version": "2.3.10",
+  "version": "2.3.12",
   "description": "JavaScript library for Curve Lending",
   "main": "lib/index.js",
   "author": "Macket",

--- a/src/constants/abis/crvUSD/controller_v2.json
+++ b/src/constants/abis/crvUSD/controller_v2.json
@@ -1015,5 +1015,22 @@
     ],
     "stateMutability": "view",
     "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "name": "arg0",
+        "type": "address"
+      }
+    ],
+    "name": "extra_health",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   }
 ]

--- a/src/lendMarkets/LendMarketTemplate.ts
+++ b/src/lendMarkets/LendMarketTemplate.ts
@@ -157,6 +157,7 @@ export class LendMarketTemplate<V extends 'v1' | 'v2' = 'v1' | 'v2'> {
             userStateBigInt: userPosition.userStateBigInt.bind(userPosition),
             userState: userPosition.userState.bind(userPosition),
             userHealth: userPosition.userHealth.bind(userPosition),
+            userDiscounts: userPosition.userDiscounts.bind(userPosition),
             userBandsBigInt: userPosition.userBandsBigInt.bind(userPosition),
             userBands: userPosition.userBands.bind(userPosition),
             userRange: userPosition.userRange.bind(userPosition),

--- a/src/lendMarkets/interfaces/common/userPosition.ts
+++ b/src/lendMarkets/interfaces/common/userPosition.ts
@@ -6,6 +6,7 @@ export interface IUserPosition {
     userBandsBigInt:(address: string) => Promise<bigint[]>,
     userState: (address?: string) => Promise<{ collateral: string, borrowed: string, debt: string, N: string, isSoftLiquidation: boolean }>,
     userHealth: (full?: boolean, address?: string) => Promise<string>,
+    userDiscounts: (address?: string) => Promise<{ loanDiscount: string, liquidationDiscount: string }>,
     userBands: (address?: string) => Promise<number[]>,
     userRange: (address?: string) => Promise<number>,
     userPrices: (address?: string) => Promise<string[]>,

--- a/src/lendMarkets/modules/common/userPosition.ts
+++ b/src/lendMarkets/modules/common/userPosition.ts
@@ -61,6 +61,19 @@ export class UserPositionModule implements IUserPosition {
         return formatUnits(_health);
     }
 
+    public async userDiscounts(address = ""): Promise<{ loanDiscount: string, liquidationDiscount: string }> {
+        address = _getAddress.call(this.llamalend, address);
+        const controller = this.llamalend.contracts[this.market.addresses.controller].multicallContract;
+        const calls = [controller.loan_discount(), controller.liquidation_discounts(address)];
+        if (this.market.version === "v2") calls.push(controller.extra_health(address));
+
+        const [_loanDiscount, _liquidationDiscount, _extraHealth = BigInt(0)] = await this.llamalend.multicallProvider.all(calls) as bigint[];
+        return {
+            loanDiscount: formatUnits((_loanDiscount + _extraHealth) * BigInt(100)),
+            liquidationDiscount: formatUnits(_liquidationDiscount * BigInt(100)),
+        };
+    }
+
     private async _userBands(address: string): Promise<bigint[]> {
         address = _getAddress.call(this.llamalend, address);
         const _bands = await this.llamalend.contracts[this.market.addresses.amm].contract.read_user_tick_numbers(address, this.llamalend.constantOptions) as bigint[];

--- a/src/mintMarkets/MintMarketTemplate.ts
+++ b/src/mintMarkets/MintMarketTemplate.ts
@@ -509,6 +509,19 @@ export class MintMarketTemplate {
         return formatUnits(_health);
     }
 
+    public async userDiscounts(address = ""): Promise<{ loanDiscount: string, liquidationDiscount: string }> {
+        address = _getAddress.call(this.llamalend, address);
+        const controller = this.llamalend.contracts[this.controller].multicallContract;
+        const calls = [controller.loan_discount(), controller.liquidation_discounts(address)];
+        if (this.isDeleverageSupported) calls.push(controller.extra_health(address));
+
+        const [_loanDiscount, _liquidationDiscount, _extraHealth = BigInt(0)] = await this.llamalend.multicallProvider.all(calls) as bigint[];
+        return {
+            loanDiscount: formatUnits((_loanDiscount + _extraHealth) * BigInt(100)),
+            liquidationDiscount: formatUnits(_liquidationDiscount * BigInt(100)),
+        };
+    }
+
     public async userBands(address = ""): Promise<number[]> {
         address = _getAddress.call(this.llamalend, address);
         const _bands = await this.llamalend.contracts[this.address].contract.read_user_tick_numbers(address, this.llamalend.constantOptions) as BigNumber[];


### PR DESCRIPTION
- Adds `userDiscounts` APIs to mint and lending markets, returning loan and liquidation discounts while accounting for v2 extra health. 
- Updates the v2 controller ABI to expose `extra_health`.