### PR TITLE
fix: allow getExpected to return no quote

### DIFF
--- a/README.md
+++ b/README.md
@@ -1006,7 +1006,7 @@ type GetExpectedFn = (
     toToken: string,        // Address of token to swap to
     amountIn: bigint,       // Amount of tokens to swap (in wei)
     blacklist: string | string[], // Contract/pool addresses to exclude
-) => Promise<IQuote>;
+) => Promise<IQuote | null>; // null when no route is found
 ```
 
 **IQuote** - quote object with swap information:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@curvefi/llamalend-api",
-  "version": "2.4.3",
+  "version": "2.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@curvefi/llamalend-api",
-      "version": "2.4.3",
+      "version": "2.5.2",
       "license": "MIT",
       "dependencies": {
         "@curvefi/ethcall": "6.0.20",
@@ -1160,7 +1160,6 @@
       "integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.2",
         "@typescript-eslint/types": "8.46.2",
@@ -1400,7 +1399,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1974,7 +1972,6 @@
       "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2256,7 +2253,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@adraffy/ens-normalize": "1.11.1",
         "@noble/curves": "1.2.0",
@@ -3684,7 +3680,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curvefi/llamalend-api",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "JavaScript library for Curve Lending",
   "main": "lib/index.js",
   "author": "Macket",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -214,7 +214,7 @@ export type GetExpectedFn = (
     toToken: string,
     amountIn: bigint,
     blacklist: string | string[],
-) => Promise<IQuote>;
+) => Promise<IQuote | null>;
 
 export interface IRates {
     borrowApr: string;

--- a/src/lendMarkets/modules/common/leverageZapV2Base.ts
+++ b/src/lendMarkets/modules/common/leverageZapV2Base.ts
@@ -161,12 +161,11 @@ export abstract class LeverageZapV2BaseModule {
                 break;
             }
 
-            const _maxAdditionalCollateral = BigInt((await getExpected(
-                this.market.addresses.borrowed_token,
-                this.market.addresses.collateral_token,
-                _maxBorrowable,
-                this.market.addresses.amm
-            )).outAmount);
+            const { borrowed_token, collateral_token, amm } = this.market.addresses;
+            const quote = await getExpected(borrowed_token, collateral_token, _maxBorrowable, amm);
+            if (quote === null) break;
+
+            const _maxAdditionalCollateral = BigInt(quote.outAmount);
 
             pAvgBN = maxBorrowableBN.div(toBN(_maxAdditionalCollateral, this.market.collateral_token.decimals));
             _maxLeverageCollateral = _maxAdditionalCollateral;
@@ -232,12 +231,11 @@ export abstract class LeverageZapV2BaseModule {
             }
 
             if (pAvgBN === null){
-                const _y = BigInt((await getExpected(
-                    this.market.addresses.borrowed_token,
-                    this.market.addresses.collateral_token,
-                    _maxBorrowable[0],
-                    this.market.addresses.amm
-                )).outAmount);
+                const { borrowed_token, collateral_token, amm } = this.market.addresses;
+                const quote = await getExpected(borrowed_token, collateral_token, _maxBorrowable[0], amm);
+                if (quote === null) break;
+
+                const _y = BigInt(quote.outAmount);
                 const yBN = toBN(_y, this.market.collateral_token.decimals);
                 pAvgBN = maxBorrowableBN[0].div(yBN);
             }
@@ -599,8 +597,11 @@ export abstract class LeverageZapV2BaseModule {
             }
 
             // additionalCollateral = (userBorrowed / p) + leverageCollateral
-            const _maxAdditionalCollateral = BigInt((await getExpected(
-                this.market.addresses.borrowed_token, this.market.addresses.collateral_token, _maxBorrowable + _userBorrowed, this.market.addresses.amm)).outAmount);
+            const { borrowed_token, collateral_token, amm } = this.market.addresses;
+            const quote = await getExpected(borrowed_token, collateral_token, _maxBorrowable + _userBorrowed, amm);
+            if (quote === null) break;
+
+            const _maxAdditionalCollateral = BigInt(quote.outAmount);
             pAvgBN = maxBorrowableBN.plus(userBorrowed).div(toBN(_maxAdditionalCollateral, this.market.collateral_token.decimals));
             _maxLeverageCollateral = _maxAdditionalCollateral - fromBN(BN(userBorrowed).div(pAvgBN), this.market.collateral_token.decimals);
         }

--- a/src/mintMarkets/modules/leverageZapV2.ts
+++ b/src/mintMarkets/modules/leverageZapV2.ts
@@ -134,12 +134,11 @@ export class MintLeverageZapV2Module {
                 break;
             }
 
-            const _maxAdditionalCollateral = BigInt((await getExpected(
-                this.market.coinAddresses[0],
-                this.market.coinAddresses[1],
-                _maxBorrowable,
-                this.market.address
-            )).outAmount);
+            const [fromToken, toToken] = this.market.coinAddresses;
+            const quote = await getExpected(fromToken, toToken, _maxBorrowable, this.market.address);
+            if (quote === null) break;
+
+            const _maxAdditionalCollateral = BigInt(quote.outAmount);
 
             pAvgBN = maxBorrowableBN.div(toBN(_maxAdditionalCollateral, this.market.coinDecimals[1]));
             _maxLeverageCollateral = _maxAdditionalCollateral;
@@ -205,12 +204,11 @@ export class MintLeverageZapV2Module {
             }
 
             if (pAvgBN === null){
-                const _y = BigInt((await getExpected(
-                    this.market.coinAddresses[0],
-                    this.market.coinAddresses[1],
-                    _maxBorrowable[0],
-                    this.market.address
-                )).outAmount);
+                const [fromToken, toToken] = this.market.coinAddresses;
+                const quote = await getExpected(fromToken, toToken, _maxBorrowable[0], this.market.address);
+                if (quote === null) break;
+
+                const _y = BigInt(quote.outAmount);
                 const yBN = toBN(_y, this.market.coinDecimals[1]);
                 pAvgBN = maxBorrowableBN[0].div(yBN);
             }
@@ -598,8 +596,11 @@ export class MintLeverageZapV2Module {
             }
 
             // additionalCollateral = (userBorrowed / p) + leverageCollateral
-            const _maxAdditionalCollateral = BigInt((await getExpected(
-                this.market.coinAddresses[0], this.market.coinAddresses[1], _maxBorrowable + _userBorrowed, this.market.address)).outAmount);
+            const [fromToken, toToken] = this.market.coinAddresses;
+            const quote = await getExpected(fromToken, toToken, _maxBorrowable + _userBorrowed, this.market.address);
+            if (quote === null) break;
+
+            const _maxAdditionalCollateral = BigInt(quote.outAmount);
             pAvgBN = maxBorrowableBN.plus(userBorrowed).div(toBN(_maxAdditionalCollateral, this.market.coinDecimals[1]));
             _maxLeverageCollateral = _maxAdditionalCollateral - fromBN(BN(userBorrowed).div(pAvgBN), this.market.coinDecimals[1]);
         }


### PR DESCRIPTION
- getExpected can return nothing when no routes are found, but llamalend.js currently throws infinity errors when outAmount is 0